### PR TITLE
Fix #29 forward_value not working for char pointers

### DIFF
--- a/src/ttauri/delayed_format.hpp
+++ b/src/ttauri/delayed_format.hpp
@@ -39,7 +39,7 @@ public:
      *             but excluding the locale.
      */
     template<typename... Args>
-    delayed_format(Args &&...args) noexcept : _values(forward_value<Args>{}(args)...)
+    delayed_format(Args const &...args) noexcept : _values(args...)
     {
     }
 

--- a/src/ttauri/forward_value.hpp
+++ b/src/ttauri/forward_value.hpp
@@ -29,50 +29,52 @@ template<typename T>
 struct forward_value {
     using type = std::remove_cvref_t<T>;
 
-    [[nodiscard]] constexpr T &&operator()(std::remove_reference_t<T> &t) const noexcept
+    [[nodiscard]] type operator()(T const &t) const noexcept
     {
-        return static_cast<T &&>(t);
-    }
-
-    [[nodiscard]] constexpr T &&operator()(std::remove_reference_t<T> &&t) const noexcept
-    {
-        static_assert(!std::is_lvalue_reference_v<T>, "Can not forward an rvalue as an lvalue.");
-        return static_cast<T &&>(t);
+        return t;
     }
 };
 
+
+#define MAKE_FORWARD_VALUE(TEMPLATE_TYPE, RETURN_TYPE, ARGUMENT_TYPE) \
+    template<> \
+    struct forward_value<TEMPLATE_TYPE> { \
+        using type = RETURN_TYPE; \
+\
+        [[nodiscard]] type operator()(ARGUMENT_TYPE t) const noexcept \
+        { \
+            return type{t}; \
+        } \
+    };
+
+// Copy string_view by string value.
+MAKE_FORWARD_VALUE(std::string_view, std::string, std::string_view const &)
+MAKE_FORWARD_VALUE(std::string_view const, std::string, std::string_view const &)
+MAKE_FORWARD_VALUE(std::string_view &, std::string, std::string_view const &)
+MAKE_FORWARD_VALUE(std::string_view const &, std::string, std::string_view const &)
+
+// Copy char pointers by string value.
+MAKE_FORWARD_VALUE(char *, std::string, char const *)
+MAKE_FORWARD_VALUE(char const *, std::string, char const *)
+MAKE_FORWARD_VALUE(char * const, std::string, char const *)
+MAKE_FORWARD_VALUE(char const * const, std::string, char const *)
+MAKE_FORWARD_VALUE(char *&, std::string, char const *)
+MAKE_FORWARD_VALUE(char const *&, std::string, char const *)
+MAKE_FORWARD_VALUE(char *const&, std::string, char const *)
+MAKE_FORWARD_VALUE(char const *const&, std::string, char const *)
+
+#undef MAKE_FORWARD_VALUE
+
+// Copy string literal by pointer.
 template<size_t N>
 struct forward_value<char const (&)[N]> {
     using type = char const *;
 
-    [[nodiscard]] constexpr char const *operator()(char const (&t)[N]) const noexcept
+    [[nodiscard]] constexpr type operator()(char const (&t)[N]) const noexcept
     {
         return static_cast<char const *>(t);
     }
 };
-
-template<>
-struct forward_value<std::string_view> {
-    using type = std::string;
-
-    [[nodiscard]] std::string operator()(std::string_view t) const noexcept
-    {
-        return std::string{t};
-    }
-};
-
-// Override for char const *, otherwise forward_value will match
-// char const (&)[].
-template<>
-struct forward_value<char const *> {
-    using type = std::string;
-
-    [[nodiscard]] std::string operator()(char const *t) const noexcept
-    {
-        return std::string{t};
-    }
-};
-
 
 /** Get the storage type of the `forward_value` functor.
  * Use this type for the variables that are assigned with the return

--- a/src/ttauri/forward_value_tests.cpp
+++ b/src/ttauri/forward_value_tests.cpp
@@ -14,9 +14,22 @@ TEST(forward_value, string_literal)
     static_assert(std::is_same_v<tt::forward_value_t<decltype("hello world")>, char const *>);
 }
 
+TEST(forward_value, char_ptr_literal)
+{
+    char const *hello_world = "hello world";
+    char const *const const_hello_world = "hello world";
+
+    static_assert(std::is_same_v<tt::forward_value_t<decltype(hello_world)>, std::string>);
+    static_assert(std::is_same_v<tt::forward_value_t<decltype(const_hello_world)>, std::string>);
+    static_assert(std::is_same_v<tt::forward_value_t<decltype(hello_world)&>, std::string>);
+    static_assert(std::is_same_v<tt::forward_value_t<decltype(const_hello_world)&>, std::string>);
+}
 TEST(forward_value, string_view)
 {
     static_assert(std::is_same_v<tt::forward_value_t<std::string_view>, std::string>);
+    static_assert(std::is_same_v<tt::forward_value_t<std::string_view const>, std::string>);
+    static_assert(std::is_same_v<tt::forward_value_t<std::string_view const &>, std::string>);
+    static_assert(std::is_same_v<tt::forward_value_t<std::string_view &>, std::string>);
 }
 
 TEST(forward_value, integer)
@@ -25,7 +38,13 @@ TEST(forward_value, integer)
     static_assert(std::is_same_v<tt::forward_value_t<int &>, int>);
     static_assert(std::is_same_v<tt::forward_value_t<int const &>, int>);
     static_assert(std::is_same_v<tt::forward_value_t<int *>, int *>);
+    static_assert(std::is_same_v<tt::forward_value_t<int * const>, int *>);
     static_assert(std::is_same_v<tt::forward_value_t<int const *>, int const *>);
+    static_assert(std::is_same_v<tt::forward_value_t<int const * const>, int const *>);
+    static_assert(std::is_same_v<tt::forward_value_t<int *&>, int *>);
+    static_assert(std::is_same_v<tt::forward_value_t<int *const&>, int *>);
+    static_assert(std::is_same_v<tt::forward_value_t<int const *&>, int const *>);
+    static_assert(std::is_same_v<tt::forward_value_t<int const *const&>, int const *>);
 }
 
 class A{};
@@ -36,5 +55,11 @@ TEST(forward_value, class_object)
     static_assert(std::is_same_v<tt::forward_value_t<A &>, A>);
     static_assert(std::is_same_v<tt::forward_value_t<A const &>, A>);
     static_assert(std::is_same_v<tt::forward_value_t<A *>, A *>);
+    static_assert(std::is_same_v<tt::forward_value_t<A * const>, A *>);
     static_assert(std::is_same_v<tt::forward_value_t<A const *>, A const *>);
+    static_assert(std::is_same_v<tt::forward_value_t<A const * const>, A const *>);
+    static_assert(std::is_same_v<tt::forward_value_t<A *&>, A *>);
+    static_assert(std::is_same_v<tt::forward_value_t<A *const&>, A *>);
+    static_assert(std::is_same_v<tt::forward_value_t<A const *&>, A const *>);
+    static_assert(std::is_same_v<tt::forward_value_t<A const *const&>, A const *>);
 }


### PR DESCRIPTION
forward_value was not converting `char const * const &` to a `std::string`