### PR TITLE
fix #38 use the modern c++20 std::memory_order

### DIFF
--- a/src/ttauri/GUI/gui_window_vulkan.cpp
+++ b/src/ttauri/GUI/gui_window_vulkan.cpp
@@ -305,7 +305,7 @@ void gui_window_vulkan::render(hires_utc_clock::time_point displayTimePoint)
     widget->set_layout_parameters(aarect{extent}, aarect{extent});
 
     // When a window message was received, such as a resize, redraw, language-change; the requestLayout is set to true.
-    ttlet need_layout = requestLayout.exchange(false, std::memory_order::memory_order_relaxed) || constraints_have_changed;
+    ttlet need_layout = requestLayout.exchange(false, std::memory_order::relaxed) || constraints_have_changed;
 
     // Make sure the widget's layout is updated before draw, but after window resize.
     widget->update_layout(displayTimePoint, need_layout);

--- a/src/ttauri/atomic.hpp
+++ b/src/ttauri/atomic.hpp
@@ -23,7 +23,7 @@ namespace tt {
  */
 template<basic_fixed_string CounterTag, typename T>
 tt_no_inline void
-contended_wait_for_transition(std::atomic<T> const &state, T to, std::memory_order order = std::memory_order_seq_cst)
+contended_wait_for_transition(std::atomic<T> const &state, T to, std::memory_order order = std::memory_order::seq_cst)
 {
     using namespace std::literals::chrono_literals;
 
@@ -54,7 +54,7 @@ contended_wait_for_transition(std::atomic<T> const &state, T to, std::memory_ord
  * @param order The memory order to use for the load atomic.
  */
 template<basic_fixed_string CounterTag, typename T>
-void wait_for_transition(std::atomic<T> const &state, T to, std::memory_order order = std::memory_order_seq_cst)
+void wait_for_transition(std::atomic<T> const &state, T to, std::memory_order order = std::memory_order::seq_cst)
 {
     if (state.load(order) != to) {
         [[unlikely]] contended_wait_for_transition<CounterTag>(state, to, order);
@@ -70,7 +70,7 @@ void wait_for_transition(std::atomic<T> const &state, T to, std::memory_order or
  * @param order Memory order to use for this state variable.
  */
 template<basic_fixed_string BlockCounterTag = "", typename T>
-tt_no_inline void contended_transition(std::atomic<T> &state, T from, T to, std::memory_order order = std::memory_order_seq_cst)
+tt_no_inline void contended_transition(std::atomic<T> &state, T from, T to, std::memory_order order = std::memory_order::seq_cst)
 {
     using namespace std::literals::chrono_literals;
 
@@ -102,7 +102,7 @@ tt_no_inline void contended_transition(std::atomic<T> &state, T from, T to, std:
  * @param order Memory order to use for this state variable.
  */
 template<basic_fixed_string BlockCounterTag = "", typename T>
-void transition(std::atomic<T> &state, T from, T to, std::memory_order order = std::memory_order_seq_cst)
+void transition(std::atomic<T> &state, T from, T to, std::memory_order order = std::memory_order::seq_cst)
 {
     auto expect = from;
     if (state.compare_exchange_strong(expect, to, order)) {

--- a/src/ttauri/counters.hpp
+++ b/src/ttauri/counters.hpp
@@ -41,7 +41,7 @@ struct counter_functor {
 
     int64_t increment() const noexcept
     {
-        ttlet value = counter.fetch_add(1, std::memory_order_relaxed);
+        ttlet value = counter.fetch_add(1, std::memory_order::relaxed);
 
         if (value == 0) {
             [[unlikely]] add_to_map();
@@ -52,7 +52,7 @@ struct counter_functor {
 
     [[nodiscard]] int64_t read() const noexcept
     {
-        return counter.load(std::memory_order_relaxed);
+        return counter.load(std::memory_order::relaxed);
     }
 
     // Don't implement readAndSet, a set to zero would cause the counters to be reinserted.
@@ -78,7 +78,7 @@ template<basic_fixed_string Tag>
     auto &item = counter_map[tag];
 
     ttlet *const count_ptr = item.counter;
-    ttlet count = count_ptr != nullptr ? item.counter->load(std::memory_order_relaxed) : 0;
+    ttlet count = count_ptr != nullptr ? item.counter->load(std::memory_order::relaxed) : 0;
     ttlet count_since_last_read = count - item.previous_value;
     item.previous_value = count;
     return {count, count_since_last_read};

--- a/src/ttauri/logger.hpp
+++ b/src/ttauri/logger.hpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <tuple>
 #include <mutex>
+#include <atomic>
 
 namespace tt {
 
@@ -224,7 +225,7 @@ inline bool logger_start()
 template<log_level Level, basic_fixed_string SourceFile, int SourceLine, basic_fixed_string Fmt, typename... Args>
 void log(Args &&...args) noexcept
 {
-    ttlet status = system_status.load(std::memory_order::memory_order_relaxed);
+    ttlet status = system_status.load(std::memory_order::relaxed);
 
     if (!static_cast<bool>(to_log_level(status) & static_cast<uint8_t>(Level))) [[likely]] {
         return;

--- a/src/ttauri/random_pcg.hpp
+++ b/src/ttauri/random_pcg.hpp
@@ -80,11 +80,11 @@ public:
     }
 
     uint32_t operator()() {
-        auto x = state.load(std::memory_order_relaxed);
+        auto x = state.load(std::memory_order::relaxed);
         uint64_t new_state;
         do {
             [[unlikely]] new_state = x * multiplier + increment;
-        } while (!state.compare_exchange_weak(x, new_state, std::memory_order_relaxed));
+        } while (!state.compare_exchange_weak(x, new_state, std::memory_order::relaxed));
 
         ttlet count = static_cast<unsigned int>(x >> 59);
 

--- a/src/ttauri/sync_clock.hpp
+++ b/src/ttauri/sync_clock.hpp
@@ -62,11 +62,11 @@ public:
     }
 
     typename slow_clock::time_point convert(typename fast_clock::time_point fast_time) const noexcept {
-        return convert(gain.load(std::memory_order_relaxed), bias.load(std::memory_order_relaxed), fast_time);
+        return convert(gain.load(std::memory_order_relaxed), bias.load(std::memory_order::relaxed), fast_time);
     }
 
     typename slow_clock::duration convert(typename fast_clock::duration fast_duration) const noexcept {
-        return convert(gain.load(std::memory_order_relaxed), fast_duration);
+        return convert(gain.load(std::memory_order::relaxed), fast_duration);
     }
 
     /* Calibrate the sync clock.
@@ -180,7 +180,7 @@ private:
 
         ttlet do_gain_calibration = calibration_nr <= 5;
 
-        ttlet new_gain = do_gain_calibration ? getGain() : gain.load(std::memory_order_relaxed);
+        ttlet new_gain = do_gain_calibration ? getGain() : gain.load(std::memory_order::relaxed);
         ttlet new_bias = getBias(new_gain);
         ttlet leap_adjustment = getLeapAdjustment(new_gain, new_bias);
 
@@ -200,9 +200,9 @@ private:
         }
         
         if (do_gain_calibration) {
-            gain.store(new_gain, std::memory_order_relaxed);
+            gain.store(new_gain, std::memory_order::relaxed);
         }
-        bias.store(new_bias + leap_adjustment, std::memory_order_relaxed);
+        bias.store(new_bias + leap_adjustment, std::memory_order::relaxed);
         leapsecond_offset += leap_adjustment;
     }
 

--- a/src/ttauri/system_status.hpp
+++ b/src/ttauri/system_status.hpp
@@ -126,7 +126,7 @@ bool system_status_start_subsystem(system_status_type subsystem, InitFunc init_f
 {
     tt_axiom(std::popcount(static_cast<uint32_t>(subsystem)) == 1);
 
-    if (!static_cast<bool>(system_status.load(std::memory_order_relaxed) & subsystem)) {
+    if (!static_cast<bool>(system_status.load(std::memory_order::relaxed) & subsystem)) {
         [[unlikely]] return detail::system_status_start_subsystem(subsystem, init_function, deinit_function);
     } else {
         // Subsystem is already running.

--- a/src/ttauri/unfair_mutex.hpp
+++ b/src/ttauri/unfair_mutex.hpp
@@ -43,7 +43,7 @@ public:
 
         // Switch to 1 means there are no waiters.
         uint32_t expected = 0;
-        if (!semaphore.compare_exchange_strong(expected, 1, std::memory_order::memory_order_acquire)) {
+        if (!semaphore.compare_exchange_strong(expected, 1, std::memory_order::acquire)) {
             [[unlikely]] lock_contented(expected);
         }
 #if TT_BUILD_TYPE == TT_BT_DEBUG
@@ -64,7 +64,7 @@ public:
 
         // Switch to 1 means there are no waiters.
         uint32_t expected = 0;
-        if (!semaphore.compare_exchange_strong(expected, 1, std::memory_order::memory_order_acquire)) {
+        if (!semaphore.compare_exchange_strong(expected, 1, std::memory_order::acquire)) {
             tt_axiom(semaphore.load() <= 2);
             [[unlikely]] return false;
         }
@@ -78,12 +78,12 @@ public:
     void unlock() noexcept {
         tt_axiom(semaphore.load() <= 2);
 
-        if (semaphore.fetch_sub(1, std::memory_order::memory_order_relaxed) != 1) {
-            [[unlikely]] semaphore.store(0, std::memory_order::memory_order_release);
+        if (semaphore.fetch_sub(1, std::memory_order::relaxed) != 1) {
+            [[unlikely]] semaphore.store(0, std::memory_order::release);
 
             semaphore.notify_one();
         } else {
-            atomic_thread_fence(std::memory_order::memory_order_release);
+            atomic_thread_fence(std::memory_order::release);
         }
 #if TT_BUILD_TYPE == TT_BT_DEBUG
         locking_thread = 0;

--- a/src/ttauri/unfair_recursive_mutex.hpp
+++ b/src/ttauri/unfair_recursive_mutex.hpp
@@ -64,7 +64,7 @@ public:
         //
         // This only works for comparing the owner with the current thread, it would
         // not work to check the owner with a thread_id of another thread.
-        if (owner.load(std::memory_order::memory_order_acquire) == current_thread_id()) {
+        if (owner.load(std::memory_order::acquire) == current_thread_id()) {
             return count;
         } else {
             return 0;
@@ -81,7 +81,7 @@ public:
         // The following load() is:
         // - valid-and-equal to thread_id when the OWNER has the lock.
         // - zero or valid-and-not-equal to thread_id when this is an OTHER thread.
-        if (owner.load(std::memory_order::memory_order_acquire) == thread_id) {
+        if (owner.load(std::memory_order::acquire) == thread_id) {
             // FIRST | OWNER
             tt_axiom(count != 0);
             ++count;
@@ -94,7 +94,7 @@ public:
             tt_axiom(count == 0);
             count = 1;
             tt_axiom(owner == 0);
-            owner.store(thread_id, std::memory_order::memory_order_release);
+            owner.store(thread_id, std::memory_order::release);
 
             return true;
 
@@ -127,7 +127,7 @@ public:
         // The following load() is:
         // - valid-and-equal to thread_id when the OWNER has the lock.
         // - zero or valid-and-not-equal to thread_id when this is an OTHER thread.
-        if (owner.load(std::memory_order::memory_order_acquire) == thread_id) {
+        if (owner.load(std::memory_order::acquire) == thread_id) {
             // FIRST | OWNER
             tt_axiom(count != 0);
             ++count;
@@ -142,7 +142,7 @@ public:
             tt_axiom(count == 0);
             count = 1;
             tt_axiom(owner == 0);
-            owner.store(thread_id, std::memory_order::memory_order_release);
+            owner.store(thread_id, std::memory_order::release);
         }
     }
 
@@ -156,7 +156,7 @@ public:
             // Only OTHER can execute in `lock()` or `try_lock()`,
             // where it will either see the thread_id of FIRST or zero.
             // In both cases the OTHER thread is detected correctly.
-            owner.store(0, std::memory_order::memory_order_release);
+            owner.store(0, std::memory_order::release);
 
             mutex.unlock();
             // OTHER

--- a/src/ttauri/wfree_unordered_map.hpp
+++ b/src/ttauri/wfree_unordered_map.hpp
@@ -85,11 +85,11 @@ public:
 
             // First look for an empty (0) item, highly likely when doing insert.
             size_t item_hash = 0;
-            if (item.hash.compare_exchange_strong(item_hash, 1, std::memory_order_acquire)) {
+            if (item.hash.compare_exchange_strong(item_hash, 1, std::memory_order::acquire)) {
                 // Success, we found an empty entry, we marked it as busy (1).
                 item.key = std::move(key);
                 item.value = value;
-                item.hash.store(hash, std::memory_order_release);
+                item.hash.store(hash, std::memory_order::release);
                 return;
 
             } else if (item_hash == hash && key == item.key) {
@@ -129,10 +129,10 @@ public:
 
             // First look for an empty (0) item, highly likely when doing insert.
             size_t item_hash = 0;
-            if (item.hash.compare_exchange_strong(item_hash, 1, std::memory_order_acquire)) {
+            if (item.hash.compare_exchange_strong(item_hash, 1, std::memory_order::acquire)) {
                 // Success, we found an empty entry, we marked it as busy (1).
                 item.key = std::move(key);
-                item.hash.store(hash, std::memory_order_release);
+                item.hash.store(hash, std::memory_order::release);
 
                 if constexpr (std::is_default_constructible_v<V>) {
                     item.value = {};
@@ -164,7 +164,7 @@ public:
         while (true) {
             auto &item = items[index];
 
-            auto item_hash = item.hash.load(std::memory_order_acquire);
+            auto item_hash = item.hash.load(std::memory_order::acquire);
 
             if (item_hash == hash && key == item.key) {
                 // Found key
@@ -194,11 +194,11 @@ public:
         auto index = hash % CAPACITY;
         while (true) {
             auto &item = items[index];
-            auto item_hash = item.hash.load(std::memory_order_acquire);
+            auto item_hash = item.hash.load(std::memory_order::acquire);
 
             if (item_hash == hash && key == item.key) {
                 // Set tombstone. Don't actually delete the key or value.
-                item.hash.store(1, std::memory_order_release);
+                item.hash.store(1, std::memory_order::release);
                 return { item.value };
 
             } else if (item_hash == 0) {


### PR DESCRIPTION
I was using std::memory_order_* and std::memory_order::memory_order_* values. Change it to use std::memory_order::* instead.