### PR TITLE
closes #4 use colors directly in drawing

### DIFF
--- a/src/ttauri/GUI/draw_context.hpp
+++ b/src/ttauri/GUI/draw_context.hpp
@@ -32,12 +32,6 @@ namespace tt {
  */
 class draw_context {
 public:
-    /// Foreground color.
-    color line_color = color(1.0, 1.0, 1.0, 1.0);
-
-    /// Fill color.
-    color fill_color = color(0.0, 0.0, 0.0, 0.0);
-
     /// Size of lines.
     float line_width = 1.0;
 
@@ -80,8 +74,6 @@ public:
         _box_vertices(&boxVertices),
         _image_vertices(&imageVertices),
         _sdf_vertices(&sdfVertices),
-        line_color(0.0, 1.0, 0.0, 1.0),
-        fill_color(1.0, 1.0, 0.0, 1.0),
         line_width(theme::global->borderWidth),
         corner_shapes(),
         clipping_rectangle(static_cast<f32x4>(window.extent))
@@ -118,7 +110,7 @@ public:
      *  - clippingRectangle
      *  - fillColor
      */
-    void draw_filled_quad(f32x4 p1, f32x4 p2, f32x4 p3, f32x4 p4) const noexcept
+    void draw_filled_quad(f32x4 p1, f32x4 p2, f32x4 p3, f32x4 p4, color fill_color) const noexcept
     {
         tt_axiom(_flat_vertices != nullptr);
         _flat_vertices->emplace_back(transform * p1, clipping_rectangle, fill_color);
@@ -134,9 +126,9 @@ public:
      *  - clippingRectangle
      *  - fillColor
      */
-    void draw_filled_quad(aarect r) const noexcept
+    void draw_filled_quad(aarect r, color fill_color) const noexcept
     {
-        draw_filled_quad(r.corner<0>(), r.corner<1>(), r.corner<2>(), r.corner<3>());
+        draw_filled_quad(r.corner<0>(), r.corner<1>(), r.corner<2>(), r.corner<3>(), fill_color);
     }
 
     /** Draw an axis aligned box
@@ -150,7 +142,7 @@ public:
      *  - shadowSize
      *  - cornerShapes
      */
-    void draw_box(aarect box) const noexcept
+    void draw_box(aarect box, color line_color, color fill_color) const noexcept
     {
         tt_axiom(_box_vertices != nullptr);
 
@@ -173,7 +165,7 @@ public:
      *  - border_color
      *  - corner_shapes
      */
-    void draw_box_with_border_inside(aarect rectangle) const noexcept
+    void draw_box_with_border_inside(aarect rectangle, color line_color, color fill_color) const noexcept
     {
         tt_axiom(_box_vertices != nullptr);
 
@@ -207,7 +199,7 @@ public:
      *  - shadowSize
      *  - cornerShapes
      */
-    void draw_box_with_border_outside(aarect rectangle) const noexcept
+    void draw_box_with_border_outside(aarect rectangle, color line_color, color fill_color) const noexcept
     {
         tt_axiom(_box_vertices != nullptr);
 
@@ -248,25 +240,25 @@ public:
      * @param text The shaped text to draw.
      * @param useContextColor When true display the text in the context's color, if false use text style color
      */
-    void draw_text(shaped_text const &text, bool useContextColor = false) const noexcept
+    void draw_text(shaped_text const &text, std::optional<color> text_color = {}) const noexcept
     {
         tt_axiom(_sdf_vertices != nullptr);
 
-        if (useContextColor) {
+        if (text_color) {
             narrow_cast<gui_device_vulkan &>(device()).SDFPipeline->placeVertices(
-                *_sdf_vertices, text, transform, clipping_rectangle, line_color);
+                *_sdf_vertices, text, transform, clipping_rectangle, *text_color);
         } else {
             narrow_cast<gui_device_vulkan &>(device()).SDFPipeline->placeVertices(
                 *_sdf_vertices, text, transform, clipping_rectangle);
         }
     }
 
-    void draw_glyph(font_glyph_ids const &glyph, aarect box) const noexcept
+    void draw_glyph(font_glyph_ids const &glyph, aarect box, color text_color) const noexcept
     {
         tt_axiom(_sdf_vertices != nullptr);
 
         narrow_cast<gui_device_vulkan &>(device()).SDFPipeline->placeVertices(
-            *_sdf_vertices, glyph, transform * box, line_color, clipping_rectangle);
+            *_sdf_vertices, glyph, transform * box, text_color, clipping_rectangle);
     }
 
     [[nodiscard]] friend bool overlaps(draw_context const &context, aarect const &rectangle) noexcept

--- a/src/ttauri/stencils/glyph_stencil.cpp
+++ b/src/ttauri/stencils/glyph_stencil.cpp
@@ -10,7 +10,7 @@ namespace tt {
 
 glyph_stencil::glyph_stencil(alignment alignment, font_glyph_ids glyph) noexcept : super(alignment), _glyph(std::move(glyph)) {}
 
-void glyph_stencil::draw(draw_context context, bool use_context_color) noexcept
+void glyph_stencil::draw(draw_context context, tt::color color) noexcept
 {
     if (std::exchange(_data_is_modified, false)) {
         _glyph_bounding_box = pipeline_SDF::device_shared::getBoundingBox(_glyph);
@@ -25,7 +25,7 @@ void glyph_stencil::draw(draw_context context, bool use_context_color) noexcept
     }
 
     context.transform = context.transform * _glyph_transform;
-    context.draw_glyph(_glyph, _glyph_bounding_box);
+    context.draw_glyph(_glyph, _glyph_bounding_box, color);
 }
 
 } // namespace tt

--- a/src/ttauri/stencils/glyph_stencil.hpp
+++ b/src/ttauri/stencils/glyph_stencil.hpp
@@ -16,7 +16,7 @@ public:
 
     glyph_stencil(alignment alignment, font_glyph_ids glyph) noexcept;
 
-    void draw(draw_context context, bool use_context_color=false) noexcept override;
+    void draw(draw_context context, tt::color color) noexcept override;
 
 private:
     font_glyph_ids _glyph;

--- a/src/ttauri/stencils/label_stencil.hpp
+++ b/src/ttauri/stencils/label_stencil.hpp
@@ -140,13 +140,13 @@ public:
         }
     }
 
-    void draw(draw_context context, bool use_context_color = false) noexcept override
+    void draw(draw_context context, tt::color color) noexcept override
     {
         if (_text_stencil) {
-            _text_stencil->draw(context, use_context_color);
+            _text_stencil->draw(context, color);
         }
         if (_icon_stencil) {
-            _icon_stencil->draw(context, use_context_color);
+            _icon_stencil->draw(context, color);
         }
     }
 

--- a/src/ttauri/stencils/pixel_map_stencil.cpp
+++ b/src/ttauri/stencils/pixel_map_stencil.cpp
@@ -20,7 +20,7 @@ pixel_map_stencil::pixel_map_stencil(tt::alignment alignment, pixel_map<sfloat_r
 
 pixel_map_stencil::pixel_map_stencil(tt::alignment alignment, URL const &url) : pixel_map_stencil(alignment, png::load(url)) {}
 
-void pixel_map_stencil::draw(draw_context context, bool use_context_color) noexcept
+void pixel_map_stencil::draw(draw_context context, tt::color color) noexcept
 {
     if (std::exchange(_data_is_modified, false)) {
         _backing = narrow_cast<gui_device_vulkan&>(context.device()).imagePipeline->makeImage(_pixel_map.extent());

--- a/src/ttauri/stencils/pixel_map_stencil.hpp
+++ b/src/ttauri/stencils/pixel_map_stencil.hpp
@@ -18,7 +18,7 @@ public:
     pixel_map_stencil(tt::alignment alignment, pixel_map<sfloat_rgba16> const &pixel_map);
     pixel_map_stencil(tt::alignment alignment, URL const &url);
 
-    void draw(draw_context context, bool use_context_color=false) noexcept override;
+    void draw(draw_context context, tt::color color) noexcept override;
 
 private:
     pixel_map<sfloat_rgba16> _pixel_map;

--- a/src/ttauri/stencils/stencil.hpp
+++ b/src/ttauri/stencils/stencil.hpp
@@ -54,9 +54,9 @@ public:
     /** Draw the cell.
      *
      * @param context The current draw context.
-     * @param use_context_color True to use the colors in the context, False to use the colors in the cell itself.
+     * @param color The color to use for drawing.
      */
-    virtual void draw(draw_context context, bool use_context_color = false) noexcept = 0;
+    virtual void draw(draw_context context, tt::color color = tt::color{}) noexcept = 0;
 
     [[nodiscard]] static std::unique_ptr<class image_stencil> make_unique(alignment alignment, icon const &icon);
 

--- a/src/ttauri/stencils/text_stencil.cpp
+++ b/src/ttauri/stencils/text_stencil.cpp
@@ -23,7 +23,7 @@ f32x4 text_stencil::preferred_extent() noexcept
     return _shaped_text.preferred_extent;
 }
 
-void text_stencil::draw(draw_context context, bool use_context_color) noexcept
+void text_stencil::draw(draw_context context, tt::color color) noexcept
 {
     auto data_is_modified = std::exchange(_data_is_modified, false);
 
@@ -37,7 +37,7 @@ void text_stencil::draw(draw_context context, bool use_context_color) noexcept
     }
 
     context.transform = context.transform * _shaped_text_transform;
-    context.draw_text(_shaped_text, use_context_color);
+    context.draw_text(_shaped_text, color);
 }
 
 } // namespace tt

--- a/src/ttauri/stencils/text_stencil.hpp
+++ b/src/ttauri/stencils/text_stencil.hpp
@@ -20,7 +20,7 @@ public:
 
     [[nodiscard]] f32x4 preferred_extent() noexcept override;
 
-    void draw(draw_context context, bool use_context_color = false) noexcept override;
+    void draw(draw_context context, tt::color color) noexcept override;
 
 private:
     std::u8string _text;

--- a/src/ttauri/widgets/abstract_button_widget.hpp
+++ b/src/ttauri/widgets/abstract_button_widget.hpp
@@ -35,15 +35,13 @@ public:
     {
     }
 
-    draw_context make_draw_context(draw_context context) const noexcept override
+    color background_color() const noexcept override
     {
-        auto new_context = super::make_draw_context(context);
-
         if (_pressed) {
-            new_context.fill_color = theme::global->fillColor(this->_semantic_layer + 2);
+            return theme::global->fillColor(this->_semantic_layer + 2);
+        } else {
+            return super::background_color();
         }
-
-        return new_context;
     }
 
     [[nodiscard]] bool accepts_keyboard_focus(keyboard_focus_group group) const noexcept

--- a/src/ttauri/widgets/button_widget.hpp
+++ b/src/ttauri/widgets/button_widget.hpp
@@ -68,24 +68,27 @@ public:
         super::update_layout(displayTimePoint, need_layout);
     }
 
+    [[nodiscard]] color background_color() const noexcept override
+    {
+        if (*this->value) {
+            return this->accent_color();
+        } else {
+            return super::background_color();
+        }
+    }
+
     void draw(draw_context context, hires_utc_clock::time_point display_time_point) noexcept override
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         if (overlaps(context, this->window_clipping_rectangle())) {
             context.corner_shapes = f32x4::broadcast(theme::global->roundingRadius);
-            if (*this->value) {
-                context.fill_color = theme::global->accentColor;
-            }
 
             // Move the border of the button in the middle of a pixel.
-            context.draw_box_with_border_inside(this->rectangle());
+            context.draw_box_with_border_inside(this->rectangle(), this->focus_color(), this->background_color());
 
-            if (*this->enabled) {
-                context.line_color = theme::global->foregroundColor;
-            }
             context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
-            _label_stencil->draw(context, true);
+            _label_stencil->draw(context, this->label_color());
         }
 
         super::draw(std::move(context), display_time_point);

--- a/src/ttauri/widgets/checkbox_widget.hpp
+++ b/src/ttauri/widgets/checkbox_widget.hpp
@@ -155,7 +155,7 @@ private:
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        context.draw_box_with_border_inside(_checkbox_rectangle);
+        context.draw_box_with_border_inside(_checkbox_rectangle, this->focus_color(), this->background_color());
     }
 
     void draw_check_mark(draw_context context) noexcept
@@ -164,17 +164,13 @@ private:
 
         context.transform = translate3{0.0, 0.0, 0.1f} * context.transform;
 
-        if (*this->enabled && this->window.active) {
-            context.line_color = theme::global->accentColor;
-        }
-
         // Checkmark or tristate.
         if (this->value == this->true_value) {
-            context.draw_glyph(_check_glyph, _check_glyph_rectangle);
+            context.draw_glyph(_check_glyph, _check_glyph_rectangle, this->accent_color());
         } else if (this->value == this->false_value) {
             ;
         } else {
-            context.draw_glyph(_minus_glyph, _minus_glyph_rectangle);
+            context.draw_glyph(_minus_glyph, _minus_glyph_rectangle, this->accent_color());
         }
     }
 
@@ -182,15 +178,11 @@ private:
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        if (*this->enabled) {
-            context.line_color = theme::global->labelStyle.color;
-        }
-
         ttlet &labelCell = this->value == this->true_value ?
             _true_label_stencil :
             this->value == this->false_value ? _false_label_stencil : _other_label_stencil;
 
-        labelCell->draw(context, true);
+        labelCell->draw(context, this->label_color());
     }
 };
 

--- a/src/ttauri/widgets/label_widget.hpp
+++ b/src/ttauri/widgets/label_widget.hpp
@@ -79,11 +79,7 @@ public:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         if (overlaps(context, this->window_clipping_rectangle())) {
-            if (*enabled) {
-                context.line_color = theme::global->labelStyle.color;
-            }
-
-            _label_cell->draw(context, true);
+            _label_cell->draw(context, this->label_color());
         }
 
         super::draw(std::move(context), display_time_point);

--- a/src/ttauri/widgets/menu_item_widget.hpp
+++ b/src/ttauri/widgets/menu_item_widget.hpp
@@ -296,6 +296,15 @@ public:
         super::draw(std::move(context), display_time_point);
     }
 
+    [[nodiscard]] color focus_color() const noexcept override
+    {
+        if (this->_focus) {
+            return super::focus_color();
+        } else {
+            return this->background_color();
+        }
+    }
+
 private:
     typename decltype(label)::callback_ptr_type _label_callback;
     std::unique_ptr<label_stencil> _label_stencil;
@@ -309,32 +318,20 @@ private:
     void draw_background(draw_context context) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
-
-        context.line_color = context.fill_color;
-        if (this->_focus && this->window.active) {
-            context.line_color = theme::global->accentColor;
-        }
-
-        context.draw_box_with_border_inside(this->rectangle());
+        context.draw_box_with_border_inside(this->rectangle(), this->focus_color(), this->background_color());
     }
 
     void draw_label(draw_context context) noexcept
     {
         context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
-        if (*this->enabled) {
-            context.line_color = theme::global->foregroundColor;
-        }
-        _label_stencil->draw(context);
+        _label_stencil->draw(context, this->label_color());
     }
 
     void draw_check_mark(draw_context context) noexcept
     {
         if (this->value == this->true_value) {
             context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
-            if (*this->enabled) {
-                context.line_color = theme::global->foregroundColor;
-            }
-            _check_mark_stencil->draw(context);
+            _check_mark_stencil->draw(context, this->accent_color());
         }
     }
 };

--- a/src/ttauri/widgets/overlay_view_widget.hpp
+++ b/src/ttauri/widgets/overlay_view_widget.hpp
@@ -90,7 +90,7 @@ private:
     void draw_background(draw_context context) noexcept
     {
         context.clipping_rectangle = expand(context.clipping_rectangle, theme::global->borderWidth);
-        context.draw_box_with_border_outside(rectangle());
+        context.draw_box_with_border_outside(rectangle(), foreground_color(), background_color());
     }
 };
 

--- a/src/ttauri/widgets/radio_button_widget.hpp
+++ b/src/ttauri/widgets/radio_button_widget.hpp
@@ -91,7 +91,7 @@ public:
             _label_rectangle = aarect{labelX, 0.0f, this->rectangle().width() - labelX, this->rectangle().height()};
             _label_stencil->set_layout_parameters(_label_rectangle, this->base_line());
 
-            _pip_rectangle = shrink(_outline_rectangle, 1.5f);
+            _pip_rectangle = shrink(_outline_rectangle, 2.5f);
         }
         super::update_layout(display_time_point, need_layout);
     }
@@ -121,7 +121,7 @@ private:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         context.corner_shapes = f32x4::broadcast(_outline_rectangle.height() * 0.5f);
-        context.draw_box_with_border_inside(_outline_rectangle);
+        context.draw_box_with_border_inside(_outline_rectangle, this->focus_color(), this->background_color());
     }
 
     void draw_pip(draw_context context) noexcept
@@ -130,24 +130,15 @@ private:
 
         // draw pip
         if (this->value == this->true_value) {
-            if (*this->enabled && this->window.active) {
-                context.line_color = theme::global->accentColor;
-            }
-            std::swap(context.line_color, context.fill_color);
             context.corner_shapes = f32x4::broadcast(_pip_rectangle.height() * 0.5f);
-            context.draw_box_with_border_inside(_pip_rectangle);
+            context.draw_box_with_border_inside(_pip_rectangle, this->accent_color(), this->accent_color());
         }
     }
 
     void draw_label(draw_context context) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
-
-        if (*this->enabled) {
-            context.line_color = theme::global->labelStyle.color;
-        }
-
-        _label_stencil->draw(context, true);
+        _label_stencil->draw(context, this->label_color());
     }
 };
 

--- a/src/ttauri/widgets/scroll_bar_widget.hpp
+++ b/src/ttauri/widgets/scroll_bar_widget.hpp
@@ -120,17 +120,17 @@ public:
     {
         ttlet lock = std::scoped_lock(gui_system_mutex);
         auto handled = super::handle_event(event);
-        
+
         if (event.cause.leftButton) {
             handled = true;
-            
+
             switch (event.type) {
-            using enum mouse_event::Type;
+                using enum mouse_event::Type;
             case ButtonDown:
                 // Record the original scroll-position before the drag starts.
                 offset_before_drag = *offset;
                 break;
-        
+
             case Drag: {
                 // The distance the slider has to move relative to the slider position at the
                 // start of the drag.
@@ -138,7 +138,7 @@ public:
                 ttlet content_movement = slider_movement * hidden_content_vs_travel_ratio();
                 offset = offset_before_drag + content_movement;
             } break;
-        
+
             default:;
             }
         }
@@ -154,9 +154,24 @@ public:
      * When the content is the same size as the scroll-view then
      * the scrollbar becomes invisible.
      */
-    [[nodiscard]] bool visible() const noexcept {
+    [[nodiscard]] bool visible() const noexcept
+    {
         tt_axiom(gui_system_mutex.recurse_lock_count());
         return hidden_content() >= 1.0f;
+    }
+
+    [[nodiscard]] color background_color() const noexcept override
+    {
+        return theme::global->fillColor(_semantic_layer);
+    }
+
+    [[nodiscard]] color foreground_color() const noexcept override
+    {
+        if (_hover) {
+            return theme::global->fillColor(_semantic_layer + 2);
+        } else {
+            return theme::global->fillColor(_semantic_layer + 1);
+        }
     }
 
 private:
@@ -230,29 +245,25 @@ private:
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        context.line_color = theme::global->fillColor(_semantic_layer);
-        context.fill_color = theme::global->fillColor(_semantic_layer);
         if constexpr (is_vertical) {
             context.corner_shapes = f32x4::broadcast(rectangle().width() * 0.5f);
         } else {
             context.corner_shapes = f32x4::broadcast(rectangle().height() * 0.5f);
         }
-        context.draw_box_with_border_inside(rectangle());
+        context.draw_box_with_border_inside(rectangle(), background_color(), background_color());
     }
 
     void draw_slider(draw_context context) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        context.line_color = theme::global->fillColor(_semantic_layer + 1);
-        context.fill_color = theme::global->fillColor(_semantic_layer + 1);
         context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
         if constexpr (is_vertical) {
             context.corner_shapes = f32x4::broadcast(slider_rectangle.width() * 0.5f);
         } else {
             context.corner_shapes = f32x4::broadcast(slider_rectangle.height() * 0.5f);
         }
-        context.draw_box_with_border_inside(slider_rectangle);
+        context.draw_box_with_border_inside(slider_rectangle, foreground_color(), foreground_color());
     }
 };
 

--- a/src/ttauri/widgets/text_field_widget.hpp
+++ b/src/ttauri/widgets/text_field_widget.hpp
@@ -379,6 +379,15 @@ public:
         return is_normal(group) && *enabled;
     }
 
+    [[nodiscard]] color focus_color() const noexcept override
+    {
+        if (*enabled && window.active && _error) {
+            return theme::global->errorLabelStyle.color;
+        } else {
+            return super::focus_color();
+        }
+    }
+
 private:
     typename decltype(value)::callback_ptr_type _value_callback;
 
@@ -495,28 +504,19 @@ private:
 
     void draw_background_box(draw_context context) const noexcept
     {
-        ttlet line_color = context.line_color;
-
-        context.line_color = context.fill_color;
         context.corner_shapes = {0.0f, 0.0f, theme::global->roundingRadius, theme::global->roundingRadius};
-        context.draw_box_with_border_inside(_text_field_rectangle);
+        context.draw_box_with_border_inside(_text_field_rectangle, background_color(), background_color());
 
         ttlet line_rectangle = aarect{_text_field_rectangle.p0(), f32x4{_text_field_rectangle.width(), context.line_width}};
         context.transform = context.transform * translate3{0.0f, 0.0f, 0.1f};
-        if (_error && window.active) {
-            context.fill_color = theme::global->errorLabelStyle.color;
-        } else {
-            context.fill_color = line_color;
-        }
-        context.draw_filled_quad(line_rectangle);
+        context.draw_filled_quad(line_rectangle, focus_color());
     }
 
     void draw_selection_rectangles(draw_context context) const noexcept
     {
         ttlet selection_rectangles = _field.selectionRectangles();
         for (ttlet selection_rectangle : selection_rectangles) {
-            context.fill_color = theme::global->textSelectColor;
-            context.draw_filled_quad(selection_rectangle);
+            context.draw_filled_quad(selection_rectangle, theme::global->textSelectColor);
         }
     }
 
@@ -524,8 +524,7 @@ private:
     {
         ttlet partial_grapheme_caret = _field.partialgraphemeCaret();
         if (partial_grapheme_caret) {
-            context.fill_color = theme::global->incompleteGlyphColor;
-            context.draw_filled_quad(partial_grapheme_caret);
+            context.draw_filled_quad(partial_grapheme_caret, theme::global->incompleteGlyphColor);
         }
     }
 
@@ -538,15 +537,14 @@ private:
         ttlet blink_is_on = nr_half_blinks % 2 == 0;
         _left_to_right_caret = _field.leftToRightCaret();
         if (_left_to_right_caret && blink_is_on && _focus && window.active) {
-            context.fill_color = theme::global->cursorColor;
-            context.draw_filled_quad(_left_to_right_caret);
+            context.draw_filled_quad(_left_to_right_caret, theme::global->cursorColor);
         }
     }
 
     void draw_text(draw_context context) const noexcept
     {
         context.transform = translate3{0.0f, 0.0f, 0.2f} * context.transform;
-        context.draw_text(_shaped_text);
+        context.draw_text(_shaped_text, label_color());
     }
 };
 

--- a/src/ttauri/widgets/toggle_widget.hpp
+++ b/src/ttauri/widgets/toggle_widget.hpp
@@ -85,7 +85,7 @@ public:
             _off_label_stencil->set_layout_parameters(_label_rectangle, base_line());
 
             _slider_rectangle =
-                shrink(aarect{0.0f, _rail_rectangle.y(), _rail_rectangle.height(), _rail_rectangle.height()}, 1.5f);
+                shrink(aarect{0.0f, _rail_rectangle.y(), _rail_rectangle.height(), _rail_rectangle.height()}, 2.5f);
 
             ttlet sliderMoveWidth = theme::global->smallSize * 2.0f - (_slider_rectangle.x() * 2.0f);
             _slider_move_range = sliderMoveWidth - _slider_rectangle.width();
@@ -129,7 +129,7 @@ private:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         drawContext.corner_shapes = f32x4::broadcast(_rail_rectangle.height() * 0.5f);
-        drawContext.draw_box_with_border_inside(_rail_rectangle);
+        drawContext.draw_box_with_border_inside(_rail_rectangle, focus_color(), background_color());
     }
 
     void draw_slider(draw_context drawContext) noexcept
@@ -143,36 +143,19 @@ private:
         }
 
         ttlet animatedValue = to_float(value, _animation_duration);
-
         ttlet positionedSliderRectangle = translate2(_slider_move_range * animatedValue, 0.0f) * _slider_rectangle;
 
-        if (*value) {
-            if (*enabled && window.active) {
-                drawContext.line_color = theme::global->accentColor;
-            }
-        } else {
-            if (*enabled && window.active) {
-                drawContext.line_color =
-                    _hover ? theme::global->borderColor(_semantic_layer + 1) : theme::global->borderColor(_semantic_layer);
-            }
-        }
-        std::swap(drawContext.line_color, drawContext.fill_color);
         drawContext.transform = translate3{0.0f, 0.0f, 0.1f} * drawContext.transform;
         drawContext.corner_shapes = f32x4::broadcast(positionedSliderRectangle.height() * 0.5f);
-        drawContext.draw_box_with_border_inside(positionedSliderRectangle);
+        drawContext.draw_box_with_border_inside(positionedSliderRectangle, accent_color(), accent_color());
     }
 
     void draw_label(draw_context drawContext) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        if (*enabled) {
-            drawContext.line_color = theme::global->labelStyle.color;
-        }
-
         ttlet &label_stencil = *value ? _on_label_stencil : _off_label_stencil;
-
-        label_stencil->draw(drawContext, true);
+        label_stencil->draw(drawContext, label_color());
     }
 };
 

--- a/src/ttauri/widgets/toolbar_tab_button_widget.hpp
+++ b/src/ttauri/widgets/toolbar_tab_button_widget.hpp
@@ -161,9 +161,8 @@ private:
             // the selected-tab (0.6) and unselected-tabs (0.8).
             parent_context.transform = translate3{0.0f, 0.0f, 1.7f} * parent_context.transform;
 
-            parent_context.fill_color = theme::global->accentColor;
             parent_context.draw_filled_quad(
-                aarect{parent_.rectangle().x(), parent_.rectangle().y(), parent_.rectangle().width(), 1.0f});
+                aarect{parent_.rectangle().x(), parent_.rectangle().y(), parent_.rectangle().width(), 1.0f}, this->focus_color());
         }
     }
 
@@ -181,20 +180,13 @@ private:
         // so that the bottom border of the tab button is not drawn.
         context.clipping_rectangle = this->parent().window_rectangle();
 
-        if (this->_hover || *this->value == this->true_value) {
-            context.fill_color = theme::global->fillColor(this->_semantic_layer - 1);
-            context.line_color = context.fill_color;
-        } else {
-            context.fill_color = theme::global->fillColor(this->_semantic_layer);
-            context.line_color = context.fill_color;
-        }
-
-        if (this->_focus && this->window.active) {
-            context.line_color = theme::global->accentColor;
-        }
+        auto button_color = (this->_hover || *this->value == this->true_value) ?
+            theme::global->fillColor(this->_semantic_layer - 1) :
+            theme::global->fillColor(this->_semantic_layer);
 
         context.corner_shapes = f32x4{0.0f, 0.0f, theme::global->roundingRadius, theme::global->roundingRadius};
-        context.draw_box_with_border_inside(_button_rectangle);
+        context.draw_box_with_border_inside(
+            _button_rectangle, (this->_focus && this->window.active) ? this->focus_color() : button_color, button_color);
     }
 
     void draw_label(draw_context context) noexcept
@@ -202,12 +194,7 @@ private:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         context.transform = translate3{0.0f, 0.0f, 0.9f} * context.transform;
-
-        if (*this->enabled) {
-            context.line_color = theme::global->labelStyle.color;
-        }
-
-        _label_stencil->draw(context, true);
+        _label_stencil->draw(context, this->label_color());
     }
 };
 

--- a/src/ttauri/widgets/toolbar_widget.hpp
+++ b/src/ttauri/widgets/toolbar_widget.hpp
@@ -110,8 +110,7 @@ public:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         if (overlaps(context, this->window_clipping_rectangle())) {
-            context.fill_color = theme::global->fillColor(_semantic_layer + 1);
-            context.draw_filled_quad(rectangle());
+            context.draw_filled_quad(rectangle(), theme::global->fillColor(_semantic_layer + 1));
         }
 
         abstract_container_widget::draw(std::move(context), display_time_point);

--- a/src/ttauri/widgets/widget.cpp
+++ b/src/ttauri/widgets/widget.cpp
@@ -61,34 +61,76 @@ void widget::update_layout(hires_utc_clock::time_point display_time_point, bool 
     }
 }
 
+
+[[nodiscard]] color widget::background_color() const noexcept
+{
+    if (*enabled) {
+        if (_hover) {
+            return theme::global->fillColor(_semantic_layer + 1);
+        } else {
+            return theme::global->fillColor(_semantic_layer);
+        }
+    } else {
+        return theme::global->fillColor(_semantic_layer - 1);
+    }
+}
+
+[[nodiscard]] color widget::foreground_color() const noexcept
+{
+    if (*enabled) {
+        if (_hover) {
+            return theme::global->borderColor(_semantic_layer + 1);
+        } else {
+            return theme::global->borderColor(_semantic_layer);
+        }
+    } else {
+        return theme::global->borderColor(_semantic_layer - 1);
+    }
+}
+
+[[nodiscard]] color widget::focus_color() const noexcept
+{
+    if (*enabled) {
+        if (_focus && window.active) {
+            return theme::global->accentColor;
+        } else if (_hover) {
+            return theme::global->borderColor(_semantic_layer + 1);
+        } else {
+            return theme::global->borderColor(_semantic_layer);
+        }
+    } else {
+        return theme::global->borderColor(_semantic_layer - 1);
+    }
+}
+
+[[nodiscard]] color widget::accent_color() const noexcept
+{
+    if (*enabled) {
+        if (window.active) {
+            return theme::global->accentColor;
+        } else {
+            return theme::global->borderColor(_semantic_layer);
+        }
+    } else {
+        return theme::global->borderColor(_semantic_layer - 1);
+    }
+}
+
+[[nodiscard]] color widget::label_color() const noexcept
+{
+    if (*enabled) {
+        return theme::global->labelStyle.color;
+    } else {
+        return theme::global->borderColor(_semantic_layer - 1);
+    }
+}
+
 draw_context widget::make_draw_context(draw_context context) const noexcept
 {
     tt_axiom(gui_system_mutex.recurse_lock_count());
 
     context.clipping_rectangle = _window_clipping_rectangle;
     context.transform = _to_window_transform;
-
-    // The default fill and border colors.
-    context.line_color = theme::global->borderColor(_semantic_layer);
-    context.fill_color = theme::global->fillColor(_semantic_layer);
-
-    if (*enabled) {
-        if (_focus && window.active) {
-            context.line_color = theme::global->accentColor;
-        } else if (_hover) {
-            context.line_color = theme::global->borderColor(_semantic_layer + 1);
-        }
-
-        if (_hover) {
-            context.fill_color = theme::global->fillColor(_semantic_layer + 1);
-        }
-
-    } else {
-        // Disabled, only the outline is shown.
-        context.line_color = theme::global->borderColor(_semantic_layer - 1);
-        context.fill_color = theme::global->fillColor(_semantic_layer - 1);
-    }
-
     return context;
 }
 

--- a/src/ttauri/widgets/widget.hpp
+++ b/src/ttauri/widgets/widget.hpp
@@ -430,6 +430,16 @@ public:
      */
     [[nodiscard]] virtual void update_layout(hires_utc_clock::time_point display_time_point, bool need_layout) noexcept;
 
+    virtual [[nodiscard]] color background_color() const noexcept;
+
+    virtual [[nodiscard]] color foreground_color() const noexcept;
+
+    virtual [[nodiscard]] color focus_color() const noexcept;
+
+    virtual [[nodiscard]] color accent_color() const noexcept;
+
+    virtual [[nodiscard]] color label_color() const noexcept;
+
     /** Make a draw context for this widget.
      * This function will make a draw context with the correct transformation
      * and default color values.

--- a/src/ttauri/widgets/window_traffic_lights_widget.cpp
+++ b/src/ttauri/widgets/window_traffic_lights_widget.cpp
@@ -111,56 +111,40 @@ window_traffic_lights_widget::update_layout(hires_utc_clock::time_point display_
     super::update_layout(display_time_point, need_layout);
 }
 
-void window_traffic_lights_widget::drawMacOS(draw_context const &drawContext, hires_utc_clock::time_point displayTimePoint) noexcept
+void window_traffic_lights_widget::drawMacOS(
+    draw_context const &drawContext,
+    hires_utc_clock::time_point displayTimePoint) noexcept
 {
     tt_axiom(gui_system_mutex.recurse_lock_count());
 
     auto context = drawContext;
     context.corner_shapes = f32x4{RADIUS, RADIUS, RADIUS, RADIUS};
 
-    if (!window.active && !_hover) {
-        context.fill_color = color(0.246f, 0.246f, 0.246f);
-    } else if (pressedClose) {
-        context.fill_color = color(1.0f, 0.242f, 0.212f);
-    } else {
-        context.fill_color = color(1.0f, 0.1f, 0.082f);
-    }
-    context.line_color = context.fill_color;
-    context.draw_box_with_border_inside(closeRectangle);
+    ttlet close_circle_color = (!window.active && !_hover) ? color(0.246f, 0.246f, 0.246f) :
+        pressedClose                                       ? color(1.0f, 0.242f, 0.212f) :
+                                                             color(1.0f, 0.1f, 0.082f);
+    context.draw_box_with_border_inside(closeRectangle, close_circle_color, close_circle_color);
 
-    if (!window.active && !_hover) {
-        context.fill_color = color(0.246f, 0.246f, 0.246f);
-    } else if (pressedMinimize) {
-        context.fill_color = color(1.0f, 0.847f, 0.093f);
-    } else {
-        context.fill_color = color(0.784f, 0.521f, 0.021f);
-    }
-    context.line_color = context.fill_color;
-    context.draw_box_with_border_inside(minimizeRectangle);
+    ttlet minimize_circle_color = (!window.active && !_hover) ? color(0.246f, 0.246f, 0.246f) :
+        pressedMinimize                                       ? color(1.0f, 0.847f, 0.093f) :
+                                                                color(0.784f, 0.521f, 0.021f);
+    context.draw_box_with_border_inside(minimizeRectangle, minimize_circle_color, minimize_circle_color);
 
-    if (!window.active && !_hover) {
-        context.fill_color = color(0.246f, 0.246f, 0.246f);
-    } else if (pressedMaximize) {
-        context.fill_color = color(0.223f, 0.863f, 0.1f);
-    } else {
-        context.fill_color = color(0.082f, 0.533f, 0.024f);
-    }
-    context.line_color = context.fill_color;
-    context.draw_box_with_border_inside(maximizeRectangle);
+    ttlet maximize_circle_color = (!window.active && !_hover) ? color(0.246f, 0.246f, 0.246f) :
+        pressedMaximize                                       ? color(0.223f, 0.863f, 0.1f) :
+                                                                color(0.082f, 0.533f, 0.024f);
+
+    context.draw_box_with_border_inside(maximizeRectangle, maximize_circle_color, maximize_circle_color);
 
     if (_hover) {
         context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
-        context.line_color = color(0.319f, 0.0f, 0.0f);
-        context.draw_glyph(closeWindowGlyph, closeWindowGlyphRectangle);
+        context.draw_glyph(closeWindowGlyph, closeWindowGlyphRectangle, color{0.319f, 0.0f, 0.0f});
+        context.draw_glyph(minimizeWindowGlyph, minimizeWindowGlyphRectangle, color{0.212f, 0.1f, 0.0f});
 
-        context.line_color = color(0.212f, 0.1f, 0.0f);
-        context.draw_glyph(minimizeWindowGlyph, minimizeWindowGlyphRectangle);
-
-        context.line_color = color(0.0f, 0.133f, 0.0f);
         if (window.size_state == gui_window_size::maximized) {
-            context.draw_glyph(restoreWindowGlyph, restoreWindowGlyphRectangle);
+            context.draw_glyph(restoreWindowGlyph, restoreWindowGlyphRectangle, color{0.0f, 0.133f, 0.0f});
         } else {
-            context.draw_glyph(maximizeWindowGlyph, maximizeWindowGlyphRectangle);
+            context.draw_glyph(maximizeWindowGlyph, maximizeWindowGlyphRectangle, color{0.0f, 0.133f, 0.0f});
         }
     }
 }
@@ -174,44 +158,38 @@ void window_traffic_lights_widget::drawWindows(
     auto context = drawContext;
 
     if (pressedClose) {
-        context.fill_color = color(1.0f, 0.0f, 0.0f);
+        context.draw_filled_quad(closeRectangle, color{1.0f, 0.0f, 0.0f});
     } else if (hoverClose) {
-        context.fill_color = color(0.5f, 0.0f, 0.0f);
+        context.draw_filled_quad(closeRectangle, color{0.5f, 0.0f, 0.0f});
     } else {
-        context.fill_color = theme::global->fillColor(_semantic_layer);
+        context.draw_filled_quad(closeRectangle, theme::global->fillColor(_semantic_layer));
     }
-    context.draw_filled_quad(closeRectangle);
 
     if (pressedMinimize) {
-        context.fill_color = theme::global->fillColor(_semantic_layer + 2);
+        context.draw_filled_quad(minimizeRectangle, theme::global->fillColor(_semantic_layer + 2));
     } else if (hoverMinimize) {
-        context.fill_color = theme::global->fillColor(_semantic_layer + 1);
+        context.draw_filled_quad(minimizeRectangle, theme::global->fillColor(_semantic_layer + 1));
     } else {
-        context.fill_color = theme::global->fillColor(_semantic_layer);
+        context.draw_filled_quad(minimizeRectangle, theme::global->fillColor(_semantic_layer));
     }
-    context.draw_filled_quad(minimizeRectangle);
 
     if (pressedMaximize) {
-        context.fill_color = theme::global->fillColor(_semantic_layer + 2);
+        context.draw_filled_quad(maximizeRectangle, theme::global->fillColor(_semantic_layer + 2));
     } else if (hoverMaximize) {
-        context.fill_color = theme::global->fillColor(_semantic_layer + 1);
+        context.draw_filled_quad(maximizeRectangle, theme::global->fillColor(_semantic_layer + 1));
     } else {
-        context.fill_color = theme::global->fillColor(_semantic_layer);
+        context.draw_filled_quad(maximizeRectangle, theme::global->fillColor(_semantic_layer));
     }
-    context.draw_filled_quad(maximizeRectangle);
 
-    if (window.active) {
-        context.line_color = theme::global->foregroundColor;
-    } else {
-        context.line_color = theme::global->borderColor(_semantic_layer);
-    }
+    ttlet glyph_color = window.active ? label_color() : foreground_color();
+
     context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
-    context.draw_glyph(closeWindowGlyph, closeWindowGlyphRectangle);
-    context.draw_glyph(minimizeWindowGlyph, minimizeWindowGlyphRectangle);
+    context.draw_glyph(closeWindowGlyph, closeWindowGlyphRectangle, glyph_color);
+    context.draw_glyph(minimizeWindowGlyph, minimizeWindowGlyphRectangle, glyph_color);
     if (window.size_state == gui_window_size::maximized) {
-        context.draw_glyph(restoreWindowGlyph, restoreWindowGlyphRectangle);
+        context.draw_glyph(restoreWindowGlyph, restoreWindowGlyphRectangle, glyph_color);
     } else {
-        context.draw_glyph(maximizeWindowGlyph, maximizeWindowGlyphRectangle);
+        context.draw_glyph(maximizeWindowGlyph, maximizeWindowGlyphRectangle, glyph_color);
     }
 }
 


### PR DESCRIPTION
Colors are no longer passed through the draw_context, instead they are passed directly in the draw calls.