### PR TITLE
close #48 Remove line_width and corner_shape from draw_context.

### DIFF
--- a/src/ttauri/GUI/pipeline_box_device_shared.hpp
+++ b/src/ttauri/GUI/pipeline_box_device_shared.hpp
@@ -9,6 +9,7 @@
 #include "../rect.hpp"
 #include "../vspan.hpp"
 #include "../color/color.hpp"
+#include "../geometry/corner_shapes.hpp"
 #include <vma/vk_mem_alloc.h>
 #include <vulkan/vulkan.hpp>
 #include <mutex>
@@ -43,14 +44,14 @@ struct device_shared final {
 
     void drawInCommandBuffer(vk::CommandBuffer &commandBuffer);
 
-    static void placeVertices(
+    static void place_vertices(
         vspan<vertex> &vertices,
+        aarect clipping_rectangle,
         rect box,
-        color backgroundColor,
-        float borderSize,
-        color borderColor,
-        f32x4 cornerShapes,
-        aarect clippingRectangle
+        color fill_color,
+        color line_color,
+        float line_width,
+        corner_shapes corner_shapes
     );
 
 private:

--- a/src/ttauri/GUI/pipeline_box_vertex.hpp
+++ b/src/ttauri/GUI/pipeline_box_vertex.hpp
@@ -23,38 +23,48 @@ struct vertex {
     sfloat_rgb32 position;
 
     //! The position in pixels of the clipping rectangle relative to the bottom-left corner of the window, and extent in pixels.
-    sfloat_rgba32 clippingRectangle;
+    sfloat_rgba32 clipping_rectangle;
 
-    //! Double 2D coordinates inside the quad, used to determine the distance from the sides and corner inside the fragment shader.
-    sfloat_rgba32 cornerCoordinate;
+    /** Double 2D coordinates inside the quad, used to determine the distance from the sides and corner inside the fragment shader.
+     * x = Number of pixels to the right from the left edge of the quad.
+     * y = Number of pixels above the bottom edge.
+     * z = Number of pixels to the left from the right edge of the quad.
+     * w = Number of pixels below the top edge.
+     * 
+     * The rasteriser will interpolate these numbers, so that inside the fragment shader
+     * the distance from a corner can be determined easily.
+     */
+    sfloat_rgba32 corner_coordinate;
 
     //! background color of the box.
-    sfloat_rgba16 backgroundColor;
+    sfloat_rgba16 fill_color;
 
     //! border color of the box.
-    sfloat_rgba16 borderColor;
+    sfloat_rgba16 line_color;
 
     //! Shape of each corner, negative values are cut corners, positive values are rounded corners.
-    sfloat_rgba16 cornerShapes;
+    sfloat_rgba16 corner_shapes;
 
-    float borderSize;
+    float line_width;
 
     vertex(
+        aarect clipping_rectangle,
         f32x4 position,
-        f32x4 cornerCoordinate,
-        color backgroundColor,
-        float borderSize,
-        color borderColor,
-        f32x4 cornerShapes,
-        aarect clippingRectangle
+        f32x4 corner_coordinate,
+        color fill_color,
+        color line_color,
+        float line_width,
+        tt::corner_shapes corner_shapes
     ) noexcept :
         position(position),
-        clippingRectangle(clippingRectangle),
-        cornerCoordinate(cornerCoordinate),
-        backgroundColor(backgroundColor),
-        borderColor(borderColor),
-        cornerShapes(cornerShapes),
-        borderSize(borderSize) {}
+        clipping_rectangle(clipping_rectangle),
+        corner_coordinate(corner_coordinate),
+        fill_color(fill_color),
+        line_color(line_color),
+        corner_shapes(corner_shapes),
+        line_width(line_width)
+    {
+    }
 
     static vk::VertexInputBindingDescription inputBindingDescription()
     {
@@ -67,12 +77,12 @@ struct vertex {
     {
         return {
             { 0, 0, vk::Format::eR32G32B32Sfloat, offsetof(vertex, position) },
-            { 1, 0, vk::Format::eR32G32B32A32Sfloat, offsetof(vertex, clippingRectangle) },
-            { 2, 0, vk::Format::eR32G32B32A32Sfloat, offsetof(vertex, cornerCoordinate) },
-            { 3, 0, vk::Format::eR16G16B16A16Sfloat, offsetof(vertex, backgroundColor) },
-            { 4, 0, vk::Format::eR16G16B16A16Sfloat, offsetof(vertex, borderColor) },
-            { 5, 0, vk::Format::eR16G16B16A16Sfloat, offsetof(vertex, cornerShapes) },
-            { 6, 0, vk::Format::eR32Sfloat, offsetof(vertex, borderSize) },
+            { 1, 0, vk::Format::eR32G32B32A32Sfloat, offsetof(vertex, clipping_rectangle) },
+            { 2, 0, vk::Format::eR32G32B32A32Sfloat, offsetof(vertex, corner_coordinate) },
+            { 3, 0, vk::Format::eR16G16B16A16Sfloat, offsetof(vertex, fill_color) },
+            { 4, 0, vk::Format::eR16G16B16A16Sfloat, offsetof(vertex, line_color) },
+            { 5, 0, vk::Format::eR16G16B16A16Sfloat, offsetof(vertex, corner_shapes) },
+            { 6, 0, vk::Format::eR32Sfloat, offsetof(vertex, line_width) },
         };
     }
 };

--- a/src/ttauri/color/sfloat_rgba16.hpp
+++ b/src/ttauri/color/sfloat_rgba16.hpp
@@ -8,6 +8,7 @@
 #include "color.hpp"
 #include "../float16.hpp"
 #include "../pixel_map.hpp"
+#include "../geometry/corner_shapes.hpp"
 #include <immintrin.h>
 #include <emmintrin.h>
 #include <algorithm>
@@ -59,6 +60,8 @@ public:
     {
         return color{static_cast<f32x4>(*this)};
     }
+
+    [[nodiscard]] sfloat_rgba16(corner_shapes const &rhs) noexcept : sfloat_rgba16(static_cast<f32x4>(rhs)) {}
 
     // std::array<float16,4> const &get() const noexcept {
     //    return v;

--- a/src/ttauri/color/sfloat_rgba32.hpp
+++ b/src/ttauri/color/sfloat_rgba32.hpp
@@ -5,6 +5,9 @@
 #pragma once
 
 #include "../numeric_array.hpp"
+#include "../geometry/corner_shapes.hpp"
+#include "../aarect.hpp"
+#include "color.hpp"
 #include <immintrin.h>
 #include <emmintrin.h>
 #include <algorithm>
@@ -13,7 +16,7 @@ namespace tt {
 
 class sfloat_rgba32 {
     // Red, Green, Blue, Alpha in binary32 (native endian).
-    std::array<float,4> v;
+    std::array<float, 4> v;
 
 public:
     sfloat_rgba32() = default;
@@ -22,35 +25,42 @@ public:
     sfloat_rgba32 &operator=(sfloat_rgba32 const &rhs) noexcept = default;
     sfloat_rgba32 &operator=(sfloat_rgba32 &&rhs) noexcept = default;
 
-    sfloat_rgba32(f32x4 const &rhs) noexcept : v(static_cast<std::array<float,4>>(rhs)) {
-    }
+    sfloat_rgba32(f32x4 const &rhs) noexcept : v(static_cast<std::array<float, 4>>(rhs)) {}
 
-    sfloat_rgba32 &operator=(f32x4 const &rhs) noexcept {
-        v = static_cast<std::array<float,4>>(rhs);
+    sfloat_rgba32 &operator=(f32x4 const &rhs) noexcept
+    {
+        v = static_cast<std::array<float, 4>>(rhs);
         return *this;
     }
 
-    operator f32x4 () const noexcept {
+    operator f32x4() const noexcept
+    {
         return f32x4{v};
     }
 
     sfloat_rgba32(aarect const &rhs) noexcept : sfloat_rgba32(rhs.v) {}
 
-    sfloat_rgba32 &operator=(aarect const &rhs) noexcept {
+    sfloat_rgba32(corner_shapes const &rhs) noexcept : sfloat_rgba32(static_cast<f32x4>(rhs)) {}
+
+    sfloat_rgba32 &operator=(aarect const &rhs) noexcept
+    {
         *this = rhs.v;
         return *this;
     }
 
-    operator aarect () const noexcept {
+    operator aarect() const noexcept
+    {
         return aarect::p0p3(f32x4(v));
     }
 
-    [[nodiscard]] friend bool operator==(sfloat_rgba32 const &lhs, sfloat_rgba32 const &rhs) noexcept {
+    [[nodiscard]] friend bool operator==(sfloat_rgba32 const &lhs, sfloat_rgba32 const &rhs) noexcept
+    {
         return lhs.v == rhs.v;
     }
-    [[nodiscard]] friend bool operator!=(sfloat_rgba32 const &lhs, sfloat_rgba32 const &rhs) noexcept {
+    [[nodiscard]] friend bool operator!=(sfloat_rgba32 const &lhs, sfloat_rgba32 const &rhs) noexcept
+    {
         return !(lhs == rhs);
     }
 };
 
-}
+} // namespace tt

--- a/src/ttauri/geometry/corner_shapes.hpp
+++ b/src/ttauri/geometry/corner_shapes.hpp
@@ -1,0 +1,50 @@
+// Copyright Take Vos 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+namespace tt {
+
+class corner_shapes {
+public:
+    constexpr corner_shapes(corner_shapes const &) noexcept = default;
+    constexpr corner_shapes(corner_shapes &&) noexcept = default;
+    constexpr corner_shapes &operator=(corner_shapes const &) noexcept = default;
+    constexpr corner_shapes &operator=(corner_shapes &&) noexcept = default;
+
+    [[nodiscard]] explicit constexpr corner_shapes() noexcept : _v() {}
+    [[nodiscard]] explicit constexpr corner_shapes(float radius) noexcept : _v(radius, radius, radius, radius) {}
+    [[nodiscard]] explicit constexpr corner_shapes(float lb, float rb, float lt, float rt) noexcept : _v(lb, rb, lt, rt) {}
+
+    [[nodiscard]] explicit constexpr operator f32x4() const noexcept
+    {
+        return _v;
+    }
+
+    [[nodiscard]] constexpr friend corner_shapes operator+(corner_shapes const &lhs, float rhs) noexcept
+    {
+        auto r = corner_shapes{};
+
+        for (size_t i = 0; i != lhs._v.size(); ++i) {
+            if (lhs._v[i] >= 0) {
+                r._v[i] = std::max(0.0f, lhs._v[i] + rhs);
+            } else {
+                r._v[i] = std::min(0.0f, lhs._v[i] - rhs);
+            }
+        }
+
+        return r;
+    }
+
+    [[nodiscard]] constexpr friend corner_shapes operator-(corner_shapes const &lhs, float rhs) noexcept
+    {
+        return lhs + -rhs;
+    }
+
+private:
+    f32x4 _v;
+};
+
+
+}

--- a/src/ttauri/version.hpp
+++ b/src/ttauri/version.hpp
@@ -20,22 +20,22 @@ struct version {
     std::string name = "ttauri";
 
     /** The version string with major.minor.patch, commits since tag, short hash of tag. */
-    std::string version_long = "0.2.3-14-g39e0db";
+    std::string version_long = "0.2.3-16-g99ace8";
 
     /** A version string containing only major.minor.patch version numbers. */
     std::string version_short = "0.2.3";
 
     /* The git tag RCS. */
-    std::string git_tag_rcs = "v0.2.3-14-g39e0db3b0d8c62a1cbee6e1cdc47cf144fa810f8-dirty";
+    std::string git_tag_rcs = "v0.2.3-16-g99ace8c30bb02e7b1c74baf9e4947c18efa0ed8a-dirty";
 
     /** Name of the git branch. */
-    std::string git_branch = "main";
+    std::string git_branch = "width-corner-shapes";
 
     /** The git commit short hash. */
-    std::string git_commit = "39e0db3";
+    std::string git_commit = "99ace8c";
 
     /** The number of commits since the version tag. */
-    int git_commits_since_version_tag = 14;
+    int git_commits_since_version_tag = 16;
 
     /** There are local changes. */
     bool git_local_changes = "dirty";

--- a/src/ttauri/widgets/button_widget.hpp
+++ b/src/ttauri/widgets/button_widget.hpp
@@ -82,10 +82,9 @@ public:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         if (overlaps(context, this->window_clipping_rectangle())) {
-            context.corner_shapes = f32x4::broadcast(theme::global->roundingRadius);
-
             // Move the border of the button in the middle of a pixel.
-            context.draw_box_with_border_inside(this->rectangle(), this->focus_color(), this->background_color());
+            context.draw_box_with_border_inside(
+                this->rectangle(), this->background_color(), this->focus_color(), corner_shapes{theme::global->roundingRadius});
 
             context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
             _label_stencil->draw(context, this->label_color());

--- a/src/ttauri/widgets/checkbox_widget.hpp
+++ b/src/ttauri/widgets/checkbox_widget.hpp
@@ -155,7 +155,7 @@ private:
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        context.draw_box_with_border_inside(_checkbox_rectangle, this->focus_color(), this->background_color());
+        context.draw_box_with_border_inside(_checkbox_rectangle, this->background_color(), this->focus_color());
     }
 
     void draw_check_mark(draw_context context) noexcept

--- a/src/ttauri/widgets/menu_item_widget.hpp
+++ b/src/ttauri/widgets/menu_item_widget.hpp
@@ -318,7 +318,7 @@ private:
     void draw_background(draw_context context) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
-        context.draw_box_with_border_inside(this->rectangle(), this->focus_color(), this->background_color());
+        context.draw_box_with_border_inside(this->rectangle(), this->background_color(), this->focus_color());
     }
 
     void draw_label(draw_context context) noexcept

--- a/src/ttauri/widgets/overlay_view_widget.hpp
+++ b/src/ttauri/widgets/overlay_view_widget.hpp
@@ -90,7 +90,7 @@ private:
     void draw_background(draw_context context) noexcept
     {
         context.clipping_rectangle = expand(context.clipping_rectangle, theme::global->borderWidth);
-        context.draw_box_with_border_outside(rectangle(), foreground_color(), background_color());
+        context.draw_box_with_border_outside(rectangle(), background_color(), foreground_color());
     }
 };
 

--- a/src/ttauri/widgets/radio_button_widget.hpp
+++ b/src/ttauri/widgets/radio_button_widget.hpp
@@ -120,8 +120,8 @@ private:
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        context.corner_shapes = f32x4::broadcast(_outline_rectangle.height() * 0.5f);
-        context.draw_box_with_border_inside(_outline_rectangle, this->focus_color(), this->background_color());
+        context.draw_box_with_border_inside(
+            _outline_rectangle, this->background_color(), this->focus_color(), corner_shapes{_outline_rectangle.height() * 0.5f});
     }
 
     void draw_pip(draw_context context) noexcept
@@ -130,8 +130,8 @@ private:
 
         // draw pip
         if (this->value == this->true_value) {
-            context.corner_shapes = f32x4::broadcast(_pip_rectangle.height() * 0.5f);
-            context.draw_box_with_border_inside(_pip_rectangle, this->accent_color(), this->accent_color());
+            context.draw_box(
+                _pip_rectangle, this->accent_color(), corner_shapes{_pip_rectangle.height() * 0.5f});
         }
     }
 

--- a/src/ttauri/widgets/scroll_bar_widget.hpp
+++ b/src/ttauri/widgets/scroll_bar_widget.hpp
@@ -245,12 +245,9 @@ private:
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        if constexpr (is_vertical) {
-            context.corner_shapes = f32x4::broadcast(rectangle().width() * 0.5f);
-        } else {
-            context.corner_shapes = f32x4::broadcast(rectangle().height() * 0.5f);
-        }
-        context.draw_box_with_border_inside(rectangle(), background_color(), background_color());
+        ttlet corner_shapes =
+            is_vertical ? tt::corner_shapes{rectangle().width() * 0.5f} : tt::corner_shapes{rectangle().height() * 0.5f};
+        context.draw_box(rectangle(), background_color(), corner_shapes);
     }
 
     void draw_slider(draw_context context) noexcept
@@ -258,12 +255,10 @@ private:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;
-        if constexpr (is_vertical) {
-            context.corner_shapes = f32x4::broadcast(slider_rectangle.width() * 0.5f);
-        } else {
-            context.corner_shapes = f32x4::broadcast(slider_rectangle.height() * 0.5f);
-        }
-        context.draw_box_with_border_inside(slider_rectangle, foreground_color(), foreground_color());
+        ttlet corner_shapes = is_vertical ? tt::corner_shapes{slider_rectangle.width() * 0.5f} :
+                                            tt::corner_shapes{slider_rectangle.height() * 0.5f};
+
+        context.draw_box(slider_rectangle, foreground_color(), corner_shapes);
     }
 };
 

--- a/src/ttauri/widgets/selection_widget.hpp
+++ b/src/ttauri/widgets/selection_widget.hpp
@@ -376,8 +376,8 @@ private:
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        context.corner_shapes = f32x4::broadcast(theme::global->roundingRadius);
-        context.draw_box_with_border_inside(rectangle(), focus_color(), background_color());
+        context.draw_box_with_border_inside(
+            rectangle(), background_color(), focus_color(), corner_shapes{theme::global->roundingRadius});
     }
 
     void draw_left_box(draw_context context) noexcept
@@ -385,9 +385,8 @@ private:
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         context.transform = translate3{0.0, 0.0, 0.1f} * context.transform;
-        context.corner_shapes = f32x4{theme::global->roundingRadius, 0.0f, theme::global->roundingRadius, 0.0f};
-        context.draw_box_with_border_inside(
-            _left_box_rectangle, focus_color(), focus_color());
+        ttlet corner_shapes = tt::corner_shapes{theme::global->roundingRadius, 0.0f, theme::global->roundingRadius, 0.0f};
+        context.draw_box(_left_box_rectangle, focus_color(), corner_shapes);
     }
 
     void draw_chevrons(draw_context context) noexcept

--- a/src/ttauri/widgets/text_field_widget.hpp
+++ b/src/ttauri/widgets/text_field_widget.hpp
@@ -504,10 +504,10 @@ private:
 
     void draw_background_box(draw_context context) const noexcept
     {
-        context.corner_shapes = {0.0f, 0.0f, theme::global->roundingRadius, theme::global->roundingRadius};
-        context.draw_box_with_border_inside(_text_field_rectangle, background_color(), background_color());
+        ttlet corner_shapes = tt::corner_shapes{0.0f, 0.0f, theme::global->roundingRadius, theme::global->roundingRadius};
+        context.draw_box(_text_field_rectangle, background_color(), corner_shapes);
 
-        ttlet line_rectangle = aarect{_text_field_rectangle.p0(), f32x4{_text_field_rectangle.width(), context.line_width}};
+        ttlet line_rectangle = aarect{_text_field_rectangle.p0(), f32x4{_text_field_rectangle.width(), 1.0}};
         context.transform = context.transform * translate3{0.0f, 0.0f, 0.1f};
         context.draw_filled_quad(line_rectangle, focus_color());
     }

--- a/src/ttauri/widgets/toggle_widget.hpp
+++ b/src/ttauri/widgets/toggle_widget.hpp
@@ -124,15 +124,15 @@ private:
     decltype(on_label)::callback_ptr_type _on_label_callback;
     decltype(off_label)::callback_ptr_type _off_label_callback;
 
-    void draw_rail(draw_context drawContext) noexcept
+    void draw_rail(draw_context draw_context) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
-        drawContext.corner_shapes = f32x4::broadcast(_rail_rectangle.height() * 0.5f);
-        drawContext.draw_box_with_border_inside(_rail_rectangle, focus_color(), background_color());
+        draw_context.draw_box_with_border_inside(
+            _rail_rectangle, background_color(), focus_color(), corner_shapes{_rail_rectangle.height() * 0.5f});
     }
 
-    void draw_slider(draw_context drawContext) noexcept
+    void draw_slider(draw_context draw_context) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
@@ -145,17 +145,17 @@ private:
         ttlet animatedValue = to_float(value, _animation_duration);
         ttlet positionedSliderRectangle = translate2(_slider_move_range * animatedValue, 0.0f) * _slider_rectangle;
 
-        drawContext.transform = translate3{0.0f, 0.0f, 0.1f} * drawContext.transform;
-        drawContext.corner_shapes = f32x4::broadcast(positionedSliderRectangle.height() * 0.5f);
-        drawContext.draw_box_with_border_inside(positionedSliderRectangle, accent_color(), accent_color());
+        draw_context.transform = translate3{0.0f, 0.0f, 0.1f} * draw_context.transform;
+        draw_context.draw_box(
+            positionedSliderRectangle, accent_color(), corner_shapes{positionedSliderRectangle.height() * 0.5f});
     }
 
-    void draw_label(draw_context drawContext) noexcept
+    void draw_label(draw_context draw_context) noexcept
     {
         tt_axiom(gui_system_mutex.recurse_lock_count());
 
         ttlet &label_stencil = *value ? _on_label_stencil : _off_label_stencil;
-        label_stencil->draw(drawContext, label_color());
+        label_stencil->draw(draw_context, label_color());
     }
 };
 

--- a/src/ttauri/widgets/toolbar_tab_button_widget.hpp
+++ b/src/ttauri/widgets/toolbar_tab_button_widget.hpp
@@ -184,9 +184,11 @@ private:
             theme::global->fillColor(this->_semantic_layer - 1) :
             theme::global->fillColor(this->_semantic_layer);
 
-        context.corner_shapes = f32x4{0.0f, 0.0f, theme::global->roundingRadius, theme::global->roundingRadius};
+        ttlet corner_shapes = tt::corner_shapes{0.0f, 0.0f, theme::global->roundingRadius, theme::global->roundingRadius};
         context.draw_box_with_border_inside(
-            _button_rectangle, (this->_focus && this->window.active) ? this->focus_color() : button_color, button_color);
+            _button_rectangle, button_color,
+            (this->_focus && this->window.active) ? this->focus_color() : button_color,
+            corner_shapes);
     }
 
     void draw_label(draw_context context) noexcept

--- a/src/ttauri/widgets/window_traffic_lights_widget.cpp
+++ b/src/ttauri/widgets/window_traffic_lights_widget.cpp
@@ -118,23 +118,22 @@ void window_traffic_lights_widget::drawMacOS(
     tt_axiom(gui_system_mutex.recurse_lock_count());
 
     auto context = drawContext;
-    context.corner_shapes = f32x4{RADIUS, RADIUS, RADIUS, RADIUS};
 
     ttlet close_circle_color = (!window.active && !_hover) ? color(0.246f, 0.246f, 0.246f) :
         pressedClose                                       ? color(1.0f, 0.242f, 0.212f) :
                                                              color(1.0f, 0.1f, 0.082f);
-    context.draw_box_with_border_inside(closeRectangle, close_circle_color, close_circle_color);
+    context.draw_box(closeRectangle, close_circle_color, corner_shapes{RADIUS});
 
     ttlet minimize_circle_color = (!window.active && !_hover) ? color(0.246f, 0.246f, 0.246f) :
         pressedMinimize                                       ? color(1.0f, 0.847f, 0.093f) :
                                                                 color(0.784f, 0.521f, 0.021f);
-    context.draw_box_with_border_inside(minimizeRectangle, minimize_circle_color, minimize_circle_color);
+    context.draw_box(minimizeRectangle, minimize_circle_color, corner_shapes{RADIUS});
 
     ttlet maximize_circle_color = (!window.active && !_hover) ? color(0.246f, 0.246f, 0.246f) :
         pressedMaximize                                       ? color(0.223f, 0.863f, 0.1f) :
                                                                 color(0.082f, 0.533f, 0.024f);
 
-    context.draw_box_with_border_inside(maximizeRectangle, maximize_circle_color, maximize_circle_color);
+    context.draw_box(maximizeRectangle, maximize_circle_color, corner_shapes{RADIUS});
 
     if (_hover) {
         context.transform = translate3{0.0f, 0.0f, 0.1f} * context.transform;


### PR DESCRIPTION
This is part of the project to remove all state from draw_context and to make widgets draw relative.