### PR TITLE
fixed md formatting and spelling [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 
 [![Build status](https://ci.appveyor.com/api/projects/status/baqx98wu1ombp3d2/branch/main?svg=true)](https://ci.appveyor.com/project/takev/ttauri/branch/main)
 
-TTauri GUI library
-==================
+# TTauri GUI library
 
 A portable, low latency, retained-mode GUI library written in C++.
 
 ![Screenshot](docs/media/screenshots/demo_v0.2.0.gif)
 
-Motivation
-----------
+## Motivation
+
 I started this library to make a portable, low latency and modern looking
 UI framework, which may also be used in proprietary (closed source) applications.
 
@@ -17,30 +16,31 @@ It is specifically designed to display information with low-latency,
 and at the screen's refresh rate. Special care is taken for making
 it easy for GUI element to observe and modify data external to the GUI.
 
-Features
---------
+## Features
 
- - Retained-mode GUI
- - Modern C++20 library.
- - Animation at the screen's refresh rate.
- - Most or all drawing is GPU accellerated, using a Vulkan backend.
- - Text is drawn using subpixel anti-aliasing and proper kerning.
- - High dynamic range and high gamut color handling.
- - High level API to make simple desktop applications.
- - Themes, including light/dark support.
- - Editable key-bindings.
- - Localization and translation.
- - Automatic application preferences storage.
- - Many support systems: logging, statistics, text-handling,
+
+- Retained-mode GUI
+- Modern C++20 library.
+- Animation at the screen's refresh rate.
+- Most or all drawing is GPU accelerated, using a Vulkan backend.
+- Text is drawn using subpixel anti-aliasing and proper kerning.
+- High dynamic range and high gamut color handling.
+- High level API to make simple desktop applications.
+- Themes, including light/dark support.
+- Editable key-bindings.
+- Localization and translation.
+- Automatic application preferences storage.
+- Many support systems: logging, statistics, text-handling,
    text template language, expression language, dynamic type system.
 
-Platform support
-----------------
-The following platforms are supported:
- - MSVC - Windows 10 - x64
+## Platform support
 
-Installation
-------------
+The following platforms are supported:
+
+- MSVC - Windows 10 - x64
+
+## Installation
+
 If you like to help with the development or want to modify ttauri you can
 find instruction how to install the dependencies and how to build ttauri in the
 [CONTRIBUTING](docs/CONTRIBUTING.md) document.
@@ -49,11 +49,10 @@ If you want to use ttauri as a linrary for your own application you can
 find instructions in the [ttauri_hello_world](https://github.com/ttauri-project/ttauri_hello_world)
 example application's [README](https://github.com/ttauri-project/ttauri_hello_world/blob/main/README.md).
 
-Sponsors
---------
+## Sponsors
+
 The following people and companies are platinum sponsors:
 
 _There are currently no platinum sponsors._
 
 for more sponsers please see [SPONSORS](SPONSORS.md).
-

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-
-[![Build status](https://ci.appveyor.com/api/projects/status/baqx98wu1ombp3d2/branch/main?svg=true)](https://ci.appveyor.com/project/takev/ttauri/branch/main)
-
-# TTauri GUI library
+TTauri GUI library [![Build status](https://ci.appveyor.com/api/projects/status/baqx98wu1ombp3d2/branch/main?svg=true)](https://ci.appveyor.com/project/takev/ttauri/branch/main)
+==================
 
 A portable, low latency, retained-mode GUI library written in C++.
 
 ![Screenshot](docs/media/screenshots/demo_v0.2.0.gif)
 
-## Motivation
+Motivation
+----------
 
 I started this library to make a portable, low latency and modern looking
 UI framework, which may also be used in proprietary (closed source) applications.
@@ -16,30 +15,32 @@ It is specifically designed to display information with low-latency,
 and at the screen's refresh rate. Special care is taken for making
 it easy for GUI element to observe and modify data external to the GUI.
 
-## Features
+Features
+--------
 
-
-- Retained-mode GUI
-- Modern C++20 library.
-- Animation at the screen's refresh rate.
-- Most or all drawing is GPU accelerated, using a Vulkan backend.
-- Text is drawn using subpixel anti-aliasing and proper kerning.
-- High dynamic range and high gamut color handling.
-- High level API to make simple desktop applications.
-- Themes, including light/dark support.
-- Editable key-bindings.
-- Localization and translation.
-- Automatic application preferences storage.
-- Many support systems: logging, statistics, text-handling,
+ - Retained-mode GUI
+ - Modern C++20 library.
+ - Animation at the screen's refresh rate.
+ - Most or all drawing is GPU accelerated, using a Vulkan backend.
+ - Text is drawn using subpixel anti-aliasing and proper kerning.
+ - High dynamic range and high gamut color handling.
+ - High level API to make simple desktop applications.
+ - Themes, including light/dark support.
+ - Editable key-bindings.
+ - Localization and translation.
+ - Automatic application preferences storage.
+ - Many support systems: logging, statistics, text-handling,
    text template language, expression language, dynamic type system.
 
-## Platform support
+Platform support
+----------------
 
 The following platforms are supported:
 
-- MSVC - Windows 10 - x64
+ - MSVC - Windows 10 - x64
 
-## Installation
+Installation
+------------
 
 If you like to help with the development or want to modify ttauri you can
 find instruction how to install the dependencies and how to build ttauri in the
@@ -49,7 +50,8 @@ If you want to use ttauri as a linrary for your own application you can
 find instructions in the [ttauri_hello_world](https://github.com/ttauri-project/ttauri_hello_world)
 example application's [README](https://github.com/ttauri-project/ttauri_hello_world/blob/main/README.md).
 
-## Sponsors
+Sponsors
+--------
 
 The following people and companies are platinum sponsors:
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,19 +1,23 @@
-# SPONSORS
+SPONSORS
+========
 
 Thank you very much to the sponsors of the ttauri-project.
 
 If you like to become a sponsor, please contribute to
 [Take Vos](https://github.com/takev/) the main developer of the ttauri-project.
 
-## Platinum sponsors
+Platinum sponsors
+-----------------
 
 _There are currently no platinum sponsors._
 
-## Gold sponsors
+Gold sponsors
+-------------
 
 _There are currently no gold sponsors._
 
-## Silver sponsors
+Silver sponsors
+---------------
 
 _There are currently no silver sponsors._
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,20 +1,19 @@
-SPONSORS
-========
+# SPONSORS
+
 Thank you very much to the sponsors of the ttauri-project.
 
 If you like to become a sponsor, please contribute to
 [Take Vos](https://github.com/takev/) the main developer of the ttauri-project.
 
-Platinum sponsors
------------------
+## Platinum sponsors
+
 _There are currently no platinum sponsors._
 
-Gold sponsors
--------------
+## Gold sponsors
+
 _There are currently no gold sponsors._
 
-Silver sponsors
-----------------
-_There are currently no silver sponsors._
+## Silver sponsors
 
+_There are currently no silver sponsors._
 

--- a/docs/BON8.md
+++ b/docs/BON8.md
@@ -1,22 +1,24 @@
-# Binary Object Notation (BON8)
+Binary Object Notation (BON8)
+=============================
 
 Here are the reasons for creating the BON8 data format:
 
-- Exact translation between JSON and BON8
-- A canonical representation to allow signing of messages.
-- No extensibility, allows every parser to handle every BON8.
-- Low amount of overhead
-- Quick encode / decode.
+ - Exact translation between JSON and BON8
+ - A canonical representation to allow signing of messages.
+ - No extensibility, allows every parser to handle every BON8.
+ - Low amount of overhead
+ - Quick encode / decode.
 
 Here are some other object-notation formats looked at:
 
-- Message Pack (complicated to parse, more data types than JSON)
-- BSON (data overhead, more data types than JSON)
-- CBOR (complicated concatenated data structure, more data types than JSON)
-- Smile (back references complicate encoding and decoding)
-- UBJSON (more data overhead)
+ - Message Pack (complicated to parse, more data types than JSON)
+ - BSON (data overhead, more data types than JSON)
+ - CBOR (complicated concatenated data structure, more data types than JSON)
+ - Smile (back references complicate encoding and decoding)
+ - UBJSON (more data overhead)
 
-## Encoding
+Encoding
+--------
 
 The idea of this encoding is that strings are encoded as UTF-8.
 
@@ -82,17 +84,18 @@ This table gives an overview on the encoding:
   fe                      | 1 | End Of Container (eoc)      |      |          |
   ff                      | 1 | End Of Text (eot)           |      |          |
 
-## Extra rules
+Extra rules
+-----------
 
 The rules below ensures minimum message size and allows for cryptographically
 signing of the message repeatably. All encoders MUST follow these rules.
 
-* String MUST ONLY end with 0xff if at least one of the following is true:
-  * The string is empty,
-  * When another string is directly following this string,
-  * If the full message is this string.
-* Integers MUST be encoded in the least amount of bytes.
-* Floating point numbers MUST be encoded in the least amount of bytes
+ - String MUST ONLY end with 0xff if at least one of the following is true:
+   - The string is empty,
+   - When another string is directly following this string,
+   - If the full message is this string.
+ - Integers MUST be encoded in the least amount of bytes.
+ - Floating point numbers MUST be encoded in the least amount of bytes
    while preserving precision. In other words: a binary64 number needs to be converted to
    binary32 and back to determine, if it can be encoded as binary32 while preserving precision.
-* Object keys MUST be lexically ordered based on UTF-8 code units.
+ - Object keys MUST be lexically ordered based on UTF-8 code units.

--- a/docs/BON8.md
+++ b/docs/BON8.md
@@ -1,21 +1,25 @@
 # Binary Object Notation (BON8)
 
 Here are the reasons for creating the BON8 data format:
- * Exact translation between JSON and BON8
- * A canonical representation to allow signing of messages.
- * No extensibility, allows every parser to handle every BON8.
- * Low amount of overhead
- * Quick encode / decode.
+
+- Exact translation between JSON and BON8
+- A canonical representation to allow signing of messages.
+- No extensibility, allows every parser to handle every BON8.
+- Low amount of overhead
+- Quick encode / decode.
 
 Here are some other object-notation formats looked at:
- * Message Pack (complicated to parse, more data types than JSON)
- * BSON (data overhead, more data types than JSON)
- * CBOR (complicated concatonated data structure, more data types than JSON)
- * Smile (back references complicate encoding and decoding)
- * UBJSON (more data overhead)
 
-## Encodig
+- Message Pack (complicated to parse, more data types than JSON)
+- BSON (data overhead, more data types than JSON)
+- CBOR (complicated concatenated data structure, more data types than JSON)
+- Smile (back references complicate encoding and decoding)
+- UBJSON (more data overhead)
+
+## Encoding
+
 The idea of this encoding is that strings are encoded as UTF-8.
+
 UTF-8 has a lot of codes that fall within the invalid range which
 can be used to encode different kinds of data.
 
@@ -45,10 +49,12 @@ array := empty_array | start_array value* eoc;
 object := empty_object | start_object (string value)* eoc
 ```
 
+This table gives an overview on the encoding:
+
   Code Sequence           | # | Type                        | Bits |      Min |       Max
  :----------------------- | -:|:-------------------------   | ----:| --------:| ----------:
   00-7f                   | 1 | UTF-8 One byte sequence     |    7 |   U+0000 |    U+007f
-  c2-df 80-bf             | 2 | UTF-8 Two byte sequence     |   11 |   U+0080 |    U+07ff      
+  c2-df 80-bf             | 2 | UTF-8 Two byte sequence     |   11 |   U+0080 |    U+07ff
   e0-ef 80-bf byte*1      | 3 | UTF-8 Three byte sequence   |   16 |   U+0800 |    U+ffff
   f0-f7 80-bf byte*2      | 4 | UTF-8 Four byte sequence    |   21 | U+100000 |  U+10ffff
   80-af                   | 1 | Positive Integer            |      |        0 |        47
@@ -69,26 +75,24 @@ object := empty_object | start_object (string value)* eoc
   f0-f7 c0-ff byte*2      | 4 | Negative Integer            |   25 |       -1 | -33554432
   f8 byte*4               | 5 | Signed integer              |   32 |    -2^31 |  2^31 - 1
   f9 byte*8               | 9 | Signed integer              |   64 |    -2^63 |  2^63 - 1
-  fa byte*4               | 5 | Floating point              |   32 |          | 
-  fb byte*8               | 9 | Floating point              |   64 |          | 
+  fa byte*4               | 5 | Floating point              |   32 |          |
+  fb byte*8               | 9 | Floating point              |   64 |          |
   fc                      | 1 | Start Array                 |      |          |
   fd                      | 1 | Start Object                |      |          |
   fe                      | 1 | End Of Container (eoc)      |      |          |
   ff                      | 1 | End Of Text (eot)           |      |          |
 
 ## Extra rules
+
 The rules below ensures minimum message size and allows for cryptographically
-signing of the message in a repeatable way. All encoders MUST follow these
-rules.
+signing of the message repeatably. All encoders MUST follow these rules.
 
- * String MUST ONLY end with 0xff if at least one of the following is true:
-   - The string is empty,
-   - When another string is directly following this string,
-   - If the full message is this string.
- * Integers MUST be encoded in the least amount of bytes.
- * Floating point numbers MUST be encoded in the least amount of bytes
+* String MUST ONLY end with 0xff if at least one of the following is true:
+  * The string is empty,
+  * When another string is directly following this string,
+  * If the full message is this string.
+* Integers MUST be encoded in the least amount of bytes.
+* Floating point numbers MUST be encoded in the least amount of bytes
    while preserving precision. In other words: a binary64 number needs to be converted to
-   binary32 and back to determine if it can be encoded as binary32 while preserving precision.
- * Object keys MUST be lexically ordered based on UTF-8 code units.
-
-
+   binary32 and back to determine, if it can be encoded as binary32 while preserving precision.
+* Object keys MUST be lexically ordered based on UTF-8 code units.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
-# Code of Conduct
+Code of Conduct
+===============
 
 This document provides community guidelines for a safe, respectful,
 productive, and collaborative place for any person who is willing to
@@ -6,10 +7,10 @@ contribute to the ttauri-project community. It applies to all
 "collaborative space", which is defined as community communications
 channels (such as mailing lists, submitted patches, commit comments, etc.).
 
-- Participants will be tolerant of opposing views.
-- Participants must ensure that their language and actions are free
+ - Participants will be tolerant of opposing views.
+ - Participants must ensure that their language and actions are free
    of personal attacks and disparaging personal remarks.
-- When interpreting the words and actions of others, participants should
+ - When interpreting the words and actions of others, participants should
    always assume good intentions.
-- Behaviour which can be reasonably considered harassment will not be
+ - Behaviour which can be reasonably considered harassment will not be
    tolerated.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,5 +1,4 @@
-Code of Conduct
-===============
+# Code of Conduct
 
 This document provides community guidelines for a safe, respectful,
 productive, and collaborative place for any person who is willing to
@@ -7,10 +6,10 @@ contribute to the ttauri-project community. It applies to all
 "collaborative space", which is defined as community communications
 channels (such as mailing lists, submitted patches, commit comments, etc.).
 
- - Participants will be tolerant of opposing views.
- - Participants must ensure that their language and actions are free
+- Participants will be tolerant of opposing views.
+- Participants must ensure that their language and actions are free
    of personal attacks and disparaging personal remarks.
- - When interpreting the words and actions of others, participants should
+- When interpreting the words and actions of others, participants should
    always assume good intentions.
- - Behaviour which can be reasonably considered harassment will not be
+- Behaviour which can be reasonably considered harassment will not be
    tolerated.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,21 +1,20 @@
-Contributing to the TTauri project
-==================================
+# Contributing to the TTauri project
 
-Issues
-------
+## Issues
+
 When you want to suggest a new feature, an improvement or file a bug
 report you can do so through an [issue](https://github.com/ttauri-project/ttauri/issues).
 
 The easiest way to contribute is by reporting issues with ttauri.
 When reporting an issue with ttauri, make sure to clearly state:
 
- - The machine setup: "Windows 10 with RenderDoc installed."
- - The steps to reproduce: "I build ttauri in x64-MSVC-Debug, then run ttauri\_demo from Visual Studio"
- - The outcome you expected: "I expected to see log messages in the Output window"
- - The actual outcome: "I get no output at all" or "I get a exception at line 123 of logger.hpp"
+- The machine setup: "Windows 10 with RenderDoc installed."
+- The steps to reproduce: "I build ttauri in x64-MSVC-Debug, then run ttauri\_demo from Visual Studio"
+- The outcome you expected: "I expected to see log messages in the Output window"
+- The actual outcome: "I get no output at all" or "I get a exception at line 123 of logger.hpp"
 
-Pull Requests
--------------
+## Pull Requests
+
 We are happy to accept pull requests for fixes, features and new widgets.
 In order to avoid wasting your time, we highly encourage opening an issue to discuss
 whether the PR you're thinking about making will be acceptable.
@@ -32,26 +31,27 @@ understand certain constructs in our code. Currently we are transitioning
 to this new code style, so you may find some code that does not conform
 to this, don't worry about this :smile:
 
-Install
--------
-Here is a description on how to install for the development of ttauri
+## Install
+
+Here is a description on how to install for the development of ttauri.
 
 ### Windows 10
 
-Install requirements:
+Installation requirements:
 
- - The latest Microsoft Visual Studio Preview from <https://visualstudio.microsoft.com/vs/preview/>
-   + C++ core desktop features
-   + C++ CMake tools for Windows
-   + Test Adapter for Google Test
-   + Windows 10 SDK
- - git from <https://git-scm.com>
- - vcpkg from <https://github.com/microsoft/vcpkg> (see below for instructions)
- - Vulkan SDK from <https://www.lunarg.com/vulkan-sdk/>
- - optional: RenderDoc (for Vulkan debugging) from <https://renderdoc.org/>
- - optional: Doxygen (for documentation generation) from <https://www.doxygen.nl/>
+- The latest Microsoft Visual Studio Preview from <https://visualstudio.microsoft.com/vs/preview/>
+  - C++ core desktop features
+  - C++ CMake tools for Windows
+  - Test Adapter for Google Test
+  - Windows 10 SDK
+- git from <https://git-scm.com>
+- vcpkg from <https://github.com/microsoft/vcpkg> (see below for instructions)
+- Vulkan SDK from <https://www.lunarg.com/vulkan-sdk/>
+- optional: RenderDoc (for Vulkan debugging) from <https://renderdoc.org/>
+- optional: Doxygen (for documentation generation) from <https://www.doxygen.nl/>
 
 To install vcpkg, we will need to do the following:
+
 ```
 c:\tools>git clone https://github.com/microsoft/vcpkg
 c:\tools>cd vcpkg
@@ -60,26 +60,29 @@ c:\tools\vcpkg>vcpkg integrate install --feature-flags=manifests
 ```
 
 To clone ttauri:
+
 ```
 c:\Users\Tjienta\Projects>git clone https://github.com/ttauri-project/ttauri
 ```
 
 #### Visual Studio 2019
+
 You can open ttauri directly in Visual Studio using the
 "[open folder](https://docs.microsoft.com/en-us/cpp/build/open-folder-projects-cpp?view=msvc-160)" method.
 
-Since it is a large project you may have to wait a minute before Visual Studio is finished with fully loading
-the project. Once it is loaded you will see a selection box with a set of build configurations:
- - x64-MSVC-Debug
- - x64-MSVC-Release
- - x64-MSVC-ReleaseWithDebugInfo
- - x64-Clang-Debug (currently not supported)
- - x64-Clang-Release (currently not supported)
- - x64-Clang-ReleaseWithDebugInfo (currently not supported)
+Since it is a large project you may have to wait a minute before Visual Studio is finished with fully loading the project. Once it is loaded you will see a selection box with a set of build configurations:
+
+- x64-MSVC-Debug
+- x64-MSVC-Release
+- x64-MSVC-ReleaseWithDebugInfo
+- x64-Clang-Debug (currently not supported)
+- x64-Clang-Release (currently not supported)
+- x64-Clang-ReleaseWithDebugInfo (currently not supported)
 
 Select the x64-MSVC-Debug and use the following menu items to build the project:
- - Project / Generate Cache for ttauri
- - Build / Build All
+
+- Project / Generate Cache for ttauri
+- Build / Build All
 
 After building you can select "ttauri_demo.exe" from "Select Startup Item..." next to the run-button. Then
 press that button to run the debug build (with the debugger attached).
@@ -88,8 +91,10 @@ You may also want to read the following about how to use CMake projects with vis
 <https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-160>
 
 #### Developer Command Prompt for VS 2019
+
 If you already have vcpkg installed you still will need to set VCPKG_ROOT and 'integrate'
 each time you start a new shell.
+
 ```
 c:\build>set VCPKG_ROOT=c:\tools\vcpkg
 c:\build>call %VCPKG_ROOT%\vcpkg integrate install --feature-flags=manifests
@@ -104,14 +109,15 @@ c:\build>cmake --build .
 ```
 
 ### Gentoo Linux
+
 **Note: TTauri does not currently build fully on Linux.**
 
 The following packages need to be installed:
 
- - app-arch/zip (needed for vcpkg)
- - dev-util/vulkan-tools (the vulkan SDK)
- - dev-util/glslang
- - media-libs/shaderc (for building the shaders)
+- app-arch/zip (needed for vcpkg)
+- dev-util/vulkan-tools (the vulkan SDK)
+- dev-util/glslang
+- media-libs/shaderc (for building the shaders)
 
 Since the vulkan sdk is part of gentoo it will be installed in `/usr`.
 
@@ -125,8 +131,8 @@ build> cmake -DVCPKG_TARGET_TRIPLET=x64-linux -DBUILD_SHARED_LIBS=ON ..
 build> cmake --build .
 ```
 
-Debugging with RenderDoc
-------------------------
+## Debugging with RenderDoc
+
 Debug builds of ttauri are linked against the RenderDoc API. Which means
 that once an ttauri-application is started you can "Attach to running process"
 and select the application there.
@@ -136,8 +142,8 @@ application may not show on this list, or you are unable to capture a frame
 or the frame is not captured. You can force a redraw by selecting the
 application window, or mouse-over the window.
 
-Testing the demo application
-----------------------------
+## Testing the demo application
+
 There is a demo application included with the releases of ttauri.
 
 It would be nice if people could test if this application will work on their computers.
@@ -155,9 +161,7 @@ To make crash mini-dump when the ttauri demo application crashes create the foll
  DumpCount    | DWORD (32-bit) Value    | 10
  DumpType     | DWORD (32-bit) Value    | 2
 
+## Code of Conduct
 
-Code of Conduct
----------------
 This project and everyone participating in it is governed by the
-(TTauri Code of Conduct)[https://github.com/ttauri-project/ttauri/blob/main/docs/CODE_OF_CONDUCT.md]
-
+[TTauri Code of Conduct](https://github.com/ttauri-project/ttauri/blob/main/docs/CODE_OF_CONDUCT.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,8 @@
-# Contributing to the TTauri project
+Contributing to the TTauri project
+==================================
 
-## Issues
+Issues
+------
 
 When you want to suggest a new feature, an improvement or file a bug
 report you can do so through an [issue](https://github.com/ttauri-project/ttauri/issues).
@@ -8,12 +10,13 @@ report you can do so through an [issue](https://github.com/ttauri-project/ttauri
 The easiest way to contribute is by reporting issues with ttauri.
 When reporting an issue with ttauri, make sure to clearly state:
 
-- The machine setup: "Windows 10 with RenderDoc installed."
-- The steps to reproduce: "I build ttauri in x64-MSVC-Debug, then run ttauri\_demo from Visual Studio"
-- The outcome you expected: "I expected to see log messages in the Output window"
-- The actual outcome: "I get no output at all" or "I get a exception at line 123 of logger.hpp"
+ - The machine setup: "Windows 10 with RenderDoc installed."
+ - The steps to reproduce: "I build ttauri in x64-MSVC-Debug, then run ttauri\_demo from Visual Studio"
+ - The outcome you expected: "I expected to see log messages in the Output window"
+ - The actual outcome: "I get no output at all" or "I get a exception at line 123 of logger.hpp"
 
-## Pull Requests
+Pull Requests
+-------------
 
 We are happy to accept pull requests for fixes, features and new widgets.
 In order to avoid wasting your time, we highly encourage opening an issue to discuss
@@ -31,7 +34,8 @@ understand certain constructs in our code. Currently we are transitioning
 to this new code style, so you may find some code that does not conform
 to this, don't worry about this :smile:
 
-## Install
+Install
+-------
 
 Here is a description on how to install for the development of ttauri.
 
@@ -39,30 +43,30 @@ Here is a description on how to install for the development of ttauri.
 
 Installation requirements:
 
-- The latest Microsoft Visual Studio Preview from <https://visualstudio.microsoft.com/vs/preview/>
-  - C++ core desktop features
-  - C++ CMake tools for Windows
-  - Test Adapter for Google Test
-  - Windows 10 SDK
-- git from <https://git-scm.com>
-- vcpkg from <https://github.com/microsoft/vcpkg> (see below for instructions)
-- Vulkan SDK from <https://www.lunarg.com/vulkan-sdk/>
-- optional: RenderDoc (for Vulkan debugging) from <https://renderdoc.org/>
-- optional: Doxygen (for documentation generation) from <https://www.doxygen.nl/>
+ - The latest Microsoft Visual Studio Preview from <https://visualstudio.microsoft.com/vs/preview/>
+   - C++ core desktop features
+   - C++ CMake tools for Windows
+   - Test Adapter for Google Test
+   - Windows 10 SDK
+ - git from <https://git-scm.com>
+ - vcpkg from <https://github.com/microsoft/vcpkg> (see below for instructions)
+ - Vulkan SDK from <https://www.lunarg.com/vulkan-sdk/>
+ - optional: RenderDoc (for Vulkan debugging) from <https://renderdoc.org/>
+ - optional: Doxygen (for documentation generation) from <https://www.doxygen.nl/>
 
 To install vcpkg, we will need to do the following:
 
 ```
-c:\tools>git clone https://github.com/microsoft/vcpkg
-c:\tools>cd vcpkg
-c:\tools\vcpkg>bootstrap-vcpkg.bat
-c:\tools\vcpkg>vcpkg integrate install --feature-flags=manifests
+c:\tools> git clone https://github.com/microsoft/vcpkg
+c:\tools> cd vcpkg
+c:\tools\vcpkg> bootstrap-vcpkg.bat
+c:\tools\vcpkg> vcpkg integrate install --feature-flags=manifests
 ```
 
 To clone ttauri:
 
 ```
-c:\Users\Tjienta\Projects>git clone https://github.com/ttauri-project/ttauri
+c:\Users\Tjienta\Projects> git clone https://github.com/ttauri-project/ttauri
 ```
 
 #### Visual Studio 2019
@@ -72,17 +76,17 @@ You can open ttauri directly in Visual Studio using the
 
 Since it is a large project you may have to wait a minute before Visual Studio is finished with fully loading the project. Once it is loaded you will see a selection box with a set of build configurations:
 
-- x64-MSVC-Debug
-- x64-MSVC-Release
-- x64-MSVC-ReleaseWithDebugInfo
-- x64-Clang-Debug (currently not supported)
-- x64-Clang-Release (currently not supported)
-- x64-Clang-ReleaseWithDebugInfo (currently not supported)
+ - x64-MSVC-Debug
+ - x64-MSVC-Release
+ - x64-MSVC-ReleaseWithDebugInfo
+ - x64-Clang-Debug (currently not supported)
+ - x64-Clang-Release (currently not supported)
+ - x64-Clang-ReleaseWithDebugInfo (currently not supported)
 
 Select the x64-MSVC-Debug and use the following menu items to build the project:
 
-- Project / Generate Cache for ttauri
-- Build / Build All
+ - Project / Generate Cache for ttauri
+ - Build / Build All
 
 After building you can select "ttauri_demo.exe" from "Select Startup Item..." next to the run-button. Then
 press that button to run the debug build (with the debugger attached).
@@ -96,12 +100,12 @@ If you already have vcpkg installed you still will need to set VCPKG_ROOT and 'i
 each time you start a new shell.
 
 ```
-c:\build>set VCPKG_ROOT=c:\tools\vcpkg
-c:\build>call %VCPKG_ROOT%\vcpkg integrate install --feature-flags=manifests
+c:\build> set VCPKG_ROOT=c:\tools\vcpkg
+c:\build> call %VCPKG_ROOT%\vcpkg integrate install --feature-flags=manifests
 ```
 
 ```
-c:\build>cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DBUILD_SHARED_LIBS=OFF ..
+c:\build> cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static -DBUILD_SHARED_LIBS=OFF ..
 ```
 
 ```
@@ -114,10 +118,10 @@ c:\build>cmake --build .
 
 The following packages need to be installed:
 
-- app-arch/zip (needed for vcpkg)
-- dev-util/vulkan-tools (the vulkan SDK)
-- dev-util/glslang
-- media-libs/shaderc (for building the shaders)
+ - app-arch/zip (needed for vcpkg)
+ - dev-util/vulkan-tools (the vulkan SDK)
+ - dev-util/glslang
+ - media-libs/shaderc (for building the shaders)
 
 Since the vulkan sdk is part of gentoo it will be installed in `/usr`.
 
@@ -131,7 +135,8 @@ build> cmake -DVCPKG_TARGET_TRIPLET=x64-linux -DBUILD_SHARED_LIBS=ON ..
 build> cmake --build .
 ```
 
-## Debugging with RenderDoc
+Debugging with RenderDoc
+------------------------
 
 Debug builds of ttauri are linked against the RenderDoc API. Which means
 that once an ttauri-application is started you can "Attach to running process"
@@ -142,7 +147,8 @@ application may not show on this list, or you are unable to capture a frame
 or the frame is not captured. You can force a redraw by selecting the
 application window, or mouse-over the window.
 
-## Testing the demo application
+Testing the demo application
+----------------------------
 
 There is a demo application included with the releases of ttauri.
 
@@ -155,13 +161,14 @@ To make crash mini-dump when the ttauri demo application crashes create the foll
 
 `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps`
 
- Name         | Type                    | Value
- ------------ | ----------------------- | ------------
- DumpFolder   | Expandable String Value | "%LOCALAPPDATA%\CrashDumps"
- DumpCount    | DWORD (32-bit) Value    | 10
- DumpType     | DWORD (32-bit) Value    | 2
+| Name       | Type                    | Value
+|------------|-------------------------|-----------------------------
+| DumpFolder | Expandable String Value | "%LOCALAPPDATA%\CrashDumps"
+| DumpCount  | DWORD (32-bit) Value    | 10
+| DumpType   | DWORD (32-bit) Value    | 2
 
-## Code of Conduct
+Code of Conduct
+---------------
 
 This project and everyone participating in it is governed by the
 [TTauri Code of Conduct](https://github.com/ttauri-project/ttauri/blob/main/docs/CODE_OF_CONDUCT.md)

--- a/docs/anti_aliasing.md
+++ b/docs/anti_aliasing.md
@@ -1,21 +1,21 @@
-Perceptive correct anti-aliasing
-================================
+# Perceptive correct anti-aliasing
 
-Terms
------
+## Terms
 
 ### Linear-sRGB color space
+
 Linear-sRGB is an inaccurate term describing a color space based on
 the sRGB color primaries and white point, but with a linear transfer function.
 
 The color component values have a range between 0.0 and 1.0 and are represented
 as floating point values. In certain cases values outside the 0.0 to 1.0 range
 are allowed to handle luminance values beyond 80 cm/m2 for HDR, or negative values
-which represent colors outside of the triangle of the sRGB color primaries.
+which represent colors outside the triangle of the sRGB color primaries.
 
 This is the color space that is used inside fragment shaders on a GPU.
 
 ### Luminance (Y)
+
 The luminance is a physical linear indication of brightness.
 
 In this paper we use the range of luminance values between 0.0 and 1.0 to
@@ -29,7 +29,7 @@ Y = 0.2126 * R + 0.7152 * G + 0.0722 * B
 ```
 
 My intuition of luminance calculations in high-gamut extended-sRGB color space
-is that the luminance is always positive. Since if a color outside of the standard sRGB
+is that the luminance is always positive. Since if a color outside the standard-sRGB
 triangle is selected at least one of the components must be a positive enough
 value to force the luminance to be above zero. Having only positive values is important
 for taking the square root, see the next section.
@@ -37,6 +37,7 @@ for taking the square root, see the next section.
 <https://en.wikipedia.org/wiki/Relative_luminance>
 
 ### Lightness (L)
+
 Lightness is the perceptual uniform indication of brightness.
 
 In this paper we use the range of lightness values between 0.0 and 1.0 to
@@ -59,8 +60,8 @@ use when doing the calculations for this paper.
 <https://en.wikipedia.org/wiki/Lightness>
 
 
-The problem
------------
+## The problem
+
 As everyone knows alpha compositing of two images must be done in the linear color
 space or there will be color and/or brightness shifts over the range of alpha values.
 
@@ -77,7 +78,7 @@ on black background and on the right side the black line on a white background.
           +----+----+----+----+----+   +----+----+----+----+----+
 coverage  | 0% |25% |100%|75% | 0% |   | 0% |25% |100%|75% | 0% |
           +----+----+----+----+----+   +----+----+----+----+----+
-          
+
           +----+----+----+----+----+   +----+----+----+----+----+
 alpha     |0.0 |0.25|1.0 |0.75|0.0 |   |0.0 |0.25|1.0 |0.75|0.0 |
           +----+----+----+----+----+   +----+----+----+----+----+
@@ -91,38 +92,36 @@ lightness |0.0 |0.5 |1.0 |0.87|0.0 |   |1.0 |0.87|0.0 |0.5 |1.0 |
           +----+----+----+----+----+   +----+----+----+----+----+
 ```
 
-The perceived line width of "white on black-background" is:
-`width = 0.0 + 0.5 + 1.0 + 0.87 + 0.0 = 2.37`
+The perceived line width of "white on black-background" is: `width = 0.0 + 0.5 + 1.0 + 0.87 + 0.0 = 2.37`
 
-The perceived line width of "black on white-background" is:
-`width = 5 - (1.0 + 0.87 + 0.0 + 0.5 + 1.0) = 1.63`
+The perceived line width of "black on white-background" is: `width = 5 - (1.0 + 0.87 + 0.0 + 0.5 + 1.0) = 1.63`
 
 As you can see the perceived width of the line is significant different
 especially when anti-aliasing objects which are thin, such as the lines
 on a glyph.
 
-The solution
-------------
+## The solution
+
 There are some papers that mention the problem of the change of apparent thickness
 of glyphs when rendering black text or white text. Most of those papers go on
 to explain this stems from not doing linear compositing, or explaining that the font
 was designed for black on white.
 
-However as you see from the calculations in the previous section this has nothing to
+However, as you see from the calculations in the previous section this has nothing to
 do with the design of a font, because it shows up even when rendering a single line.
-Also if you would render the font without anti-aliasing these problems no longer
+Also, if you would render the font without anti-aliasing these problems no longer
 exist, such as when rendering with a high resolution printer.
 
 Problems like this even happen with physical anti-alias filters, such as when using
-an anti-alias glass in front of a image sensor, which scatter the photons over range
+an anti-alias glass in front of an image sensor, which scatter the photons over range
 of pixels. It often shows as a reduction of contrast of textured images and on sharp edges,
 normally this is solved by increasing the contrast of high frequency content, such
-as using a sharpen-filter, or with professional cameras using a equalizer tuned on
+as using a sharpen-filter, or with professional cameras using an equalizer tuned on
 the whole optical system.
 
 Since with computer graphics we have control over anti-aliasing itself
 we can make the algorithm mix the foreground and background color on a
-perceptional uniform gradiant.
+perceptional uniform gradient.
 
 The calculation below shows how to convert an anti-alias-pixel-coverage value
 to an alpha value, when this pixel coverage is in a perceptional uniform space.
@@ -133,9 +132,9 @@ final composite of the foreground and background color using the two alpha value
 
 ```
 Yfront = 0.2126 * Rfront + 0.7152 * Gfront + 0.0722 * Bfront
-Yback = 0.2126 * Rback + 0.7152 * Gback + 0.0722 * Bback
+Yback  = 0.2126 * Rback + 0.7152 * Gback + 0.0722 * Bback
 Lfront = sqrt(Yfront)
-Lback = sqrt(Yback)
+Lback  = sqrt(Yback)
 ```
 
 By mixing the foreground and background lightness using the coverage value, we
@@ -147,16 +146,17 @@ Ltarget = mix(Lback, Lfront, coverage)
 
 We can convert this target lightness to a target luminance, which can then be used to find
 the alpha value needed to reach that target from the foreground and background luminance.
-If the luminance of the background and foreground are the same, then that means only
-the color is different, in that case linearly map the coverage to alpha.
+If the luminance of the background and foreground are the same, then only the color is
+different and we can linearly map the coverage to alpha.
 
 ```
 Ytarget = Ltarget * Ltarget
-alpha = (Ytarget - Yback) / (Yfront - Yback)       if Yfront != Yback
-alpha = coverage                                   otherwise
+alpha   = (Ytarget - Yback) / (Yfront - Yback)       if Yfront != Yback
+alpha   = coverage                                   otherwise
 ```
 
 ### Example
+
 Below we calculate what we will perceptional see when anti-aliasing a vertical
 line of two pixels wide centered at x=2.25. On the left side a white line
 on black background and on the right side the black line on a white background.
@@ -186,8 +186,8 @@ The perceived line width of "white on black-background" is:
 The perceived line width of "black on white-background" is:
 `width = 5 - (1.0 + 0.75 + 0.0 + 0.25 + 1.0) = 2`
 
-sub-pixel anti-aliasing
------------------------
+## Sub-pixel anti-aliasing
+
 During sub-pixel anti-aliasing we get a coverage value at each
 sub-pixel location.
 

--- a/docs/anti_aliasing.md
+++ b/docs/anti_aliasing.md
@@ -1,6 +1,8 @@
-# Perceptive correct anti-aliasing
+Perceptive correct anti-aliasing
+================================
 
-## Terms
+Terms
+-----
 
 ### Linear-sRGB color space
 
@@ -60,7 +62,8 @@ use when doing the calculations for this paper.
 <https://en.wikipedia.org/wiki/Lightness>
 
 
-## The problem
+The problem
+-----------
 
 As everyone knows alpha compositing of two images must be done in the linear color
 space or there will be color and/or brightness shifts over the range of alpha values.
@@ -100,7 +103,8 @@ As you can see the perceived width of the line is significant different
 especially when anti-aliasing objects which are thin, such as the lines
 on a glyph.
 
-## The solution
+The solution
+------------
 
 There are some papers that mention the problem of the change of apparent thickness
 of glyphs when rendering black text or white text. Most of those papers go on
@@ -186,7 +190,8 @@ The perceived line width of "white on black-background" is:
 The perceived line width of "black on white-background" is:
 `width = 5 - (1.0 + 0.75 + 0.0 + 0.25 + 1.0) = 2`
 
-## Sub-pixel anti-aliasing
+Sub-pixel anti-aliasing
+-----------------------
 
 During sub-pixel anti-aliasing we get a coverage value at each
 sub-pixel location.

--- a/docs/code_style.md
+++ b/docs/code_style.md
@@ -1,39 +1,41 @@
-Code Style rules
-================
+# Code Style rules
 
-Identifiers
------------
+## Identifiers
 
 ### Casing
+
 The following identifiers are in snake\_case:
- - functions,
- - member functions,
- - variables,
- - member variables,
- - arguments,
- - enum values,
- - struct types,
- - union types,
- - enum types,
- - concepts.
+
+- functions,
+- member functions,
+- variables,
+- member variables,
+- arguments,
+- enum values,
+- struct types,
+- union types,
+- enum types,
+- concepts.
 
 The following identifiers are in CamelCase:
- - template arguments.
+
+- template arguments.
 
 Capital letters within a snake\_case identifier are allowed for proper nouns and
 abbreviations.
 
 ### Prefixes and Suffixes
+
 Common prefixes and suffixes:
 
- - prefix `num_`: Size of a list of items. The prefixed name should be plural
- - suffix `_nr`: Ordinal of an item.
- - suffix `_i` `_j` `_k`: Index inside a loop associated with an specific list.
- - suffix `_it` `_jt` `_kt1`: Iterator inside a loop associated with an specific list.
- - prefix `_`: Private or protected member variables and functions.
- - suffix `_`: A variable after conversion to a different type.
- - prefix `tt_`: A macro
- - suffix `_type`: A type created inside a class.
+- prefix `num_`: Size of a list of items. The prefixed name should be plural
+- suffix `_nr`: Ordinal of an item.
+- suffix `_i` `_j` `_k`: Index inside a loop associated with an specific list.
+- suffix `_it` `_jt` `_kt1`: Iterator inside a loop associated with an specific list.
+- prefix `_`: Private or protected member variables and functions.
+- suffix `_`: A variable after conversion to a different type.
+- prefix `tt_`: A macro
+- suffix `_type`: A type created inside a class.
 
 Private or protected member variables are prefixed with "\_", so that
 getter/setter member functions names will not alias with the variables.
@@ -47,9 +49,8 @@ The suffix "\_" may be used when a new variable needs to be introduced
 when only its type has changed using casting or conversion.
 If more than one such variable is needed the name of the type should be appended.
 
+## Global variables
 
-Global variables
-----------------
 Singletons (classes that can only be instantiated once) are discouraged.
 
 Instead add a static-member-function to the class, which returns a reference to an instance
@@ -66,13 +67,13 @@ and underscore "\_" as separator.
 Another interesting global variable, either as a static-member-variable or as a global
 variable would be a mutex named `mutex`.
 
-Two phase construction
-----------------------
+## Two phase construction
+
 When a polymorphic class needs to polymorphic initialization and destruction it should
 add the following two virtual functions:
 
- - virtual void `init()`
- - virtual void `deinit()`
+- virtual void `init()`
+- virtual void `deinit()`
 
 `init()` should be called directly after the lifetime of the object has started. It should be called
 from the same thread as its construction and the reference to the object should not have been shared
@@ -85,8 +86,8 @@ of the current function.
 This means that like in the constructor and destructor inside `init()` and `deinit()` there is no need
 for handling multithreading issues.
 
-Delegates
----------
+## Delegates
+
 Delegates are polymorphic class instances that are passed to an object that is being managed.
 The managed object will call into the delegate to send messages and retrieve information.
 
@@ -98,15 +99,15 @@ object.
 
 Delegates should at least have the following two function to handle the lifetime of the managed object:
 
- - virtual void init(managed\_object &sender)
- - virtual void deinit(managed\_object &sender)
+- virtual void init(managed\_object &sender)
+- virtual void deinit(managed\_object &sender)
 
 The two functions mirror the two phase construction and are often called from `init()` and `deinit()` of the managed
 object. However they may be called from the constructor and destructor of the object as well.
 
-Subsystems
-----------
+## Subsystems
+
 A subsystem will have a name in the `system_status_type` enum, and will have a global function under the same name
-suffixed with \_start. This subsystem_start function is used to initialize and register the deinitalize function
+suffixed with \_start. This subsystem_start function is used to initialize and register the deinitialize function
 with the system_status. The subsystem_start function must be low latency so that it can be called very often to make
 sure the subsystem is started when functionality of the subsystem is used for the first time.

--- a/docs/code_style.md
+++ b/docs/code_style.md
@@ -1,25 +1,27 @@
-# Code Style rules
+Code Style rules
+================
 
-## Identifiers
+Identifiers
+-----------
 
 ### Casing
 
 The following identifiers are in snake\_case:
 
-- functions,
-- member functions,
-- variables,
-- member variables,
-- arguments,
-- enum values,
-- struct types,
-- union types,
-- enum types,
-- concepts.
+ - functions,
+ - member functions,
+ - variables,
+ - member variables,
+ - arguments,
+ - enum values,
+ - struct types,
+ - union types,
+ - enum types,
+ - concepts.
 
 The following identifiers are in CamelCase:
 
-- template arguments.
+ - template arguments.
 
 Capital letters within a snake\_case identifier are allowed for proper nouns and
 abbreviations.
@@ -28,14 +30,14 @@ abbreviations.
 
 Common prefixes and suffixes:
 
-- prefix `num_`: Size of a list of items. The prefixed name should be plural
-- suffix `_nr`: Ordinal of an item.
-- suffix `_i` `_j` `_k`: Index inside a loop associated with an specific list.
-- suffix `_it` `_jt` `_kt1`: Iterator inside a loop associated with an specific list.
-- prefix `_`: Private or protected member variables and functions.
-- suffix `_`: A variable after conversion to a different type.
-- prefix `tt_`: A macro
-- suffix `_type`: A type created inside a class.
+ - prefix `num_`: Size of a list of items. The prefixed name should be plural
+ - suffix `_nr`: Ordinal of an item.
+ - suffix `_i` `_j` `_k`: Index inside a loop associated with an specific list.
+ - suffix `_it` `_jt` `_kt1`: Iterator inside a loop associated with an specific list.
+ - prefix `_`: Private or protected member variables and functions.
+ - suffix `_`: A variable after conversion to a different type.
+ - prefix `tt_`: A macro
+ - suffix `_type`: A type created inside a class.
 
 Private or protected member variables are prefixed with "\_", so that
 getter/setter member functions names will not alias with the variables.
@@ -49,7 +51,8 @@ The suffix "\_" may be used when a new variable needs to be introduced
 when only its type has changed using casting or conversion.
 If more than one such variable is needed the name of the type should be appended.
 
-## Global variables
+Global variables
+----------------
 
 Singletons (classes that can only be instantiated once) are discouraged.
 
@@ -67,13 +70,14 @@ and underscore "\_" as separator.
 Another interesting global variable, either as a static-member-variable or as a global
 variable would be a mutex named `mutex`.
 
-## Two phase construction
+Two phase construction
+----------------------
 
 When a polymorphic class needs to polymorphic initialization and destruction it should
 add the following two virtual functions:
 
-- virtual void `init()`
-- virtual void `deinit()`
+ - virtual void `init()`
+ - virtual void `deinit()`
 
 `init()` should be called directly after the lifetime of the object has started. It should be called
 from the same thread as its construction and the reference to the object should not have been shared
@@ -86,7 +90,8 @@ of the current function.
 This means that like in the constructor and destructor inside `init()` and `deinit()` there is no need
 for handling multithreading issues.
 
-## Delegates
+Delegates
+---------
 
 Delegates are polymorphic class instances that are passed to an object that is being managed.
 The managed object will call into the delegate to send messages and retrieve information.
@@ -99,13 +104,14 @@ object.
 
 Delegates should at least have the following two function to handle the lifetime of the managed object:
 
-- virtual void init(managed\_object &sender)
-- virtual void deinit(managed\_object &sender)
+ - virtual void init(managed\_object &sender)
+ - virtual void deinit(managed\_object &sender)
 
 The two functions mirror the two phase construction and are often called from `init()` and `deinit()` of the managed
 object. However they may be called from the constructor and destructor of the object as well.
 
-## Subsystems
+Subsystems
+----------
 
 A subsystem will have a name in the `system_status_type` enum, and will have a global function under the same name
 suffixed with \_start. This subsystem_start function is used to initialize and register the deinitialize function

--- a/docs/color.md
+++ b/docs/color.md
@@ -1,8 +1,7 @@
-Color
-=====
+# Color
 
-Extended Linear sRGB
---------------------
+## Extended Linear sRGB
+
 Absolute color values uses the extended-linear-sRGB color space internally in
 the application, the ttauri library and its shaders. This allows for HDR (high dynamic range)
 and high gamut colors while remaining backward compatible with normal sRGB and rec709 colors.
@@ -14,8 +13,8 @@ a linear transfer function, where the value (0.0, 0.0, 0.0) is 0 cd/m2 black and
 Values above 1.0 for high dynamic range, and values below 0.0 for high gamut are
 allowed.
 
-Alpha
------
+## Alpha
+
 Alpha is encoded as a linear floating point number between 0.0 (transparent) and 1.0 (opaque).
 
 Inside the application and ttauri-library the color values are NOT pre-multiplied with the alpha value.
@@ -24,22 +23,22 @@ However the shaders may pre-multiply alpha internally for optimization or color 
 When anti-aliasing the coverage value is directly used as the alpha value during compositing.
 For text we use a more accurate anti-aliasing algorithm, for details see: [Anti Aliasing](anti_aliasing.md)
 
-Color format type
------------------
+## Color format type
+
 Color format types are used in vertex arrays when communicating with the GPU.
 
 The types have the following syntax: `numeric-type` \_ `color-components` [ \_pack ]
 
 ### Numeric type
 
-   Type   | Description
-  :------ |:-------------------------------------------------------------------------
-   norm   | Signed integer mapped to the floating point range between -1.0 and 1.0.
-   unorm  | Unsigned integer mapped to the floating point range between 0.0 and 1.0.
-   int    | Signed integer
-   uint   | Unsigned integer
-   float  | Floating point number.
-   srgb   | Non-linear sRGB format for the RGB component, the alpha remains linear. Values are mapped to a floating point range between 0.0 and 1.0.
+Type  | Description
+------|-----------------------------------------------------------------------------------------------------------------------------------------
+norm  | Signed integer mapped to the floating point range between -1.0 and 1.0.
+unorm | Unsigned integer mapped to the floating point range between 0.0 and 1.0.
+int   | Signed integer
+uint  | Unsigned integer
+float | Floating point number.
+srgb  | Non-linear sRGB format for the RGB component, the alpha remains linear. Values are mapped to a floating point range between 0.0 and 1.0.
 
 ### Color components
 
@@ -49,16 +48,16 @@ before it.
 
 Here are a few examples of components:
 
-   Combination | Description
-  :----------- |:---------------------
-   rgba32      | 32 bits per component red, green, blue & alpha
-   rgba16      | 16 bits per component red, green, blue & alpha
-   rgba8       | 8 bits per component red, green, blue & alpha
-   rgb8        | 8 bits per component red, green, blue
-   rg8         | 8 bits per component red, green
-   r8          | 8 bits per component red
-   abgr8       | 8 bits per component alpha, blue, green & red
-   a2bgr10     | 2 bit alpha, 10 bits per component blue, green & red
+Combination | Description
+------------|-----------------------------------------------------
+rgba32      | 32 bits per component red, green, blue & alpha
+rgba16      | 16 bits per component red, green, blue & alpha
+rgba8       | 8 bits per component red, green, blue & alpha
+rgb8        | 8 bits per component red, green, blue
+rg8         | 8 bits per component red, green
+r8          | 8 bits per component red
+abgr8       | 8 bits per component alpha, blue, green & red
+a2bgr10     | 2 bit alpha, 10 bits per component blue, green & red
 
 ### Packing
 
@@ -69,6 +68,3 @@ with in increasing memory addresses.
 If the format is packed, then the color components are packed together in a single integer.
 The color components are packed inside the integer from msb to lsb.
 he integer is 8, 16, 32, 64 or 128 bits in size. The integer is stored in memory in native-byte-order.
-
-
-

--- a/docs/color.md
+++ b/docs/color.md
@@ -1,6 +1,8 @@
-# Color
+Color
+=====
 
-## Extended Linear sRGB
+Extended Linear sRGB
+--------------------
 
 Absolute color values uses the extended-linear-sRGB color space internally in
 the application, the ttauri library and its shaders. This allows for HDR (high dynamic range)
@@ -13,7 +15,8 @@ a linear transfer function, where the value (0.0, 0.0, 0.0) is 0 cd/m2 black and
 Values above 1.0 for high dynamic range, and values below 0.0 for high gamut are
 allowed.
 
-## Alpha
+Alpha
+-----
 
 Alpha is encoded as a linear floating point number between 0.0 (transparent) and 1.0 (opaque).
 
@@ -23,7 +26,8 @@ However the shaders may pre-multiply alpha internally for optimization or color 
 When anti-aliasing the coverage value is directly used as the alpha value during compositing.
 For text we use a more accurate anti-aliasing algorithm, for details see: [Anti Aliasing](anti_aliasing.md)
 
-## Color format type
+Color format type
+-----------------
 
 Color format types are used in vertex arrays when communicating with the GPU.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,25 +1,24 @@
-Dependencies
-============
+# Dependencies
 
 The current dependencies are:
 
- - **Vulkan SDK** (required)
- - **Vulkan Memory Allocator**
- - **date** (c++20 preview)
- - **fmt** (c++20 preview)
- - **tzdata** (c++20 preview)
- - **Google Test** (optional, testing)
- - **Doxygen** (optional, documentation generator)
- - **RenderDoc** (optional, interoperability)
+- **Vulkan SDK** (required)
+- **Vulkan Memory Allocator**
+- **date**
+- **fmt**
+- **tzdata**
+- **Google Test** (optional, testing)
+- **Doxygen** (optional, documentation generator)
+- **RenderDoc** (optional, interoperability)
 
-Policy for adding dependencies
-------------------------------
+## Policy for adding dependencies
+
 To make ttauri easy to integrate in your own application we try to limit
 the number of dependencies to the absolute minimum.
 
- - We will allow libraries to be included which implement a preview of an
+- We will allow libraries to be included which implement a preview of an
    accepted c++ standard feature.
- - Dependencies that are required to integrate with the operating system or
-   integrate with another application are also allowes.
- - We will also allow dependencies that are required by the build environment.
- - Good quality support libraries.
+- Dependencies that are required to integrate with the operating system or
+   integrate with another application are also allowed.
+- We will also allow dependencies that are required by the build environment.
+- Good quality support libraries.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,24 +1,26 @@
-# Dependencies
+Dependencies
+============
 
 The current dependencies are:
 
-- **Vulkan SDK** (required)
-- **Vulkan Memory Allocator**
-- **date**
-- **fmt**
-- **tzdata**
-- **Google Test** (optional, testing)
-- **Doxygen** (optional, documentation generator)
-- **RenderDoc** (optional, interoperability)
+ - **Vulkan SDK** (required)
+ - **Vulkan Memory Allocator**
+ - **date**
+ - **fmt**
+ - **tzdata**
+ - **Google Test** (optional, testing)
+ - **Doxygen** (optional, documentation generator)
+ - **RenderDoc** (optional, interoperability)
 
-## Policy for adding dependencies
+Policy for adding dependencies
+------------------------------
 
 To make ttauri easy to integrate in your own application we try to limit
 the number of dependencies to the absolute minimum.
 
-- We will allow libraries to be included which implement a preview of an
+ - We will allow libraries to be included which implement a preview of an
    accepted c++ standard feature.
-- Dependencies that are required to integrate with the operating system or
+ - Dependencies that are required to integrate with the operating system or
    integrate with another application are also allowed.
-- We will also allow dependencies that are required by the build environment.
-- Good quality support libraries.
+ - We will also allow dependencies that are required by the build environment.
+ - Good quality support libraries.

--- a/docs/geometry.md
+++ b/docs/geometry.md
@@ -1,6 +1,8 @@
-# TTauri Geometry System
+TTauri Geometry System
+======================
 
-## Low level geometry types
+Low level geometry types
+------------------------
 
 ### numeric_array<T,N>
 
@@ -13,7 +15,8 @@ constexpr and easily to vectorize by the optimizer.
 The `f32x4` is an `numeric_array<float,4>` many of the operations on a `f32x4`
 are hand optimized using the intel intrinsics on SSE registers.
 
-## High level geometry type
+High level geometry type
+------------------------
 
 ### geo::vector<D>
 
@@ -44,9 +47,9 @@ Both `extent2` and `extent3` are implemented as a `f32x4` homogeneous 4D coordin
 Corner shapes are 4 floating point numbers one for the corner in the left-bottom, right-bottom,
 left-top and right-top corner. Each number has the following meaning:
 
-- 0.0 Sharp corner,
-- >0.0 Radius of a rounded corner,
-- <0.0 Radius of a cut corner.
+ - 0.0 Sharp corner,
+ - >0.0 Radius of a rounded corner,
+ - <0.0 Radius of a cut corner.
 
 ### color
 
@@ -73,12 +76,13 @@ A rectangle can be converted back to an axis_aligned_rectangle, as a bounding re
 
 a axis_aligned_rectangle is implemented as a `f32x4` where:
 
-- x - left-bottom point x.
-- y - left-bottom point y.
-- z - right-top point x.
-- w - right-top point y.
+ - x - left-bottom point x.
+ - y - left-bottom point y.
+ - z - right-top point x.
+ - w - right-top point y.
 
-## Transformation types
+Transformation types
+--------------------
 
 ### geo::identity
 
@@ -99,17 +103,18 @@ Vector * matrix multiplications are performed as if the vector is a column.
 
 ### geo::transform
 
-## Coordinates
+Coordinates
+-----------
 
 All origins (0, 0, 0) are at the bottom-left-far corner. With the x-axis pointing
 right, y-axis pointing up, z-axis pointing near.
 
 This is true for:
 
-- Window
-- Images
-- Paths
-- Font-glyphs
+ - Window
+ - Images
+ - Paths
+ - Font-glyphs
 
 ### Window and Widget-surface coordinates
 
@@ -137,9 +142,9 @@ Z-coordinate for a window is between 0.0 (far) to 100.0 (near).
 For better precision we use a reverse-z method, to combine
 1/z together with float with linear precision.
 
-- The window-widget is set to depth 0.0.
-- Each nested widget, which needs to draw itself, is 1.0 nearer.
-- Widgets which extends across other widgets, such as a combo-box-widget
+ - The window-widget is set to depth 0.0.
+ - Each nested widget, which needs to draw itself, is 1.0 nearer.
+ - Widgets which extends across other widgets, such as a combo-box-widget
    will be 25.0 nearer.
 
 ### Image coordinates
@@ -159,31 +164,34 @@ X-axis pointing right, Y-axis pointing up.
 The origin (0,0) is on the crossing of the base line and left side bearing.
 Vertices of front faces are specified in counter clockwise order.
 
-## Corners
+Corners
+-------
 
 Corners are enumerated as follows:
 
-- 0: near bottom left
-- 1: near bottom right
-- 2: near top left
-- 3: near top right
-- 4: far bottom left
-- 5: far bottom right
-- 6: far top left
-- 7: far top right
+ - 0: near bottom left
+ - 1: near bottom right
+ - 2: near top left
+ - 3: near top right
+ - 4: far bottom left
+ - 5: far bottom right
+ - 6: far top left
+ - 7: far top right
 
 When corners are passing as 4D vectors:
 
-- x = bottom-left
-- y = bottom-right
-- z = top-left
-- w = top-right
+ - x = bottom-left
+ - y = bottom-right
+ - z = top-left
+ - w = top-right
 
-## Triangles
+Triangles
+---------
 
 A front facing triangle has the vertex ordered in counter-clockwise direction.
 
-## Quads
+Quads
+-----
 
 Quads are defined as two front facing triangles.
 The vertex index order is: 0, 1, 2, 2, 1, 3

--- a/docs/geometry.md
+++ b/docs/geometry.md
@@ -6,7 +6,7 @@
 
 The `numeric_array` is an array of numbers, with many mathematical operations
 on the array of numbers. The numeric_array is designed to be useable in
-constexpr and easilly to vectorize by the optimizer.
+constexpr and easily to vectorize by the optimizer.
 
 ### f32x4
 
@@ -21,7 +21,7 @@ A vector is a direction and distance.
 
 When transforming a vector, only scale, rotation and shear have effect.
 
-Both `vector2` and `vector3` are implemented as a `f32x4` homogenious 4D coordinate with w = 0.0.
+Both `vector2` and `vector3` are implemented as a `f32x4` homogeneous 4D coordinate with w = 0.0.
 
 ### geo::point<D>
 
@@ -29,7 +29,7 @@ A point is a location in space.
 
 A point can be transformed in the same way as a vector and also be translated.
 
-Both `point2` and `point3` are implemented as a `f32x4` homogenious 4D coordinate with w = 1.0.
+Both `point2` and `point3` are implemented as a `f32x4` homogeneous 4D coordinate with w = 1.0.
 
 ### geo::extent<D>
 
@@ -37,7 +37,7 @@ An extend is a width, height and depth.
 
 A extent can be transformed like a vector.
 
-Both `extent2` and `extent3` are implemented as a `f32x4` homegeniuos 4D coordindate with w = 0.0.
+Both `extent2` and `extent3` are implemented as a `f32x4` homogeneous 4D coordinate with w = 0.0.
 
 ### corner_shapes
 

--- a/docs/geometry.md
+++ b/docs/geometry.md
@@ -1,57 +1,62 @@
-TTauri Geometry System
-======================
+# TTauri Geometry System
 
-Low level geometry types
-------------------------
+## Low level geometry types
 
 ### numeric_array<T,N>
+
 The `numeric_array` is an array of numbers, with many mathematical operations
 on the array of numbers. The numeric_array is designed to be useable in
 constexpr and easilly to vectorize by the optimizer.
 
 ### f32x4
+
 The `f32x4` is an `numeric_array<float,4>` many of the operations on a `f32x4`
 are hand optimized using the intel intrinsics on SSE registers.
 
-High level geometry type
-------------------------
+## High level geometry type
 
 ### geo::vector<D>
+
 A vector is a direction and distance.
- 
+
 When transforming a vector, only scale, rotation and shear have effect.
 
 Both `vector2` and `vector3` are implemented as a `f32x4` homogenious 4D coordinate with w = 0.0.
 
 ### geo::point<D>
+
 A point is a location in space.
- 
+
 A point can be transformed in the same way as a vector and also be translated.
 
 Both `point2` and `point3` are implemented as a `f32x4` homogenious 4D coordinate with w = 1.0.
 
 ### geo::extent<D>
+
 An extend is a width, height and depth.
- 
+
 A extent can be transformed like a vector.
- 
+
 Both `extent2` and `extent3` are implemented as a `f32x4` homegeniuos 4D coordindate with w = 0.0.
 
 ### corner_shapes
+
 Corner shapes are 4 floating point numbers one for the corner in the left-bottom, right-bottom,
 left-top and right-top corner. Each number has the following meaning:
 
- - 0.0 Sharp corner,
- - >0.0 Radius of a rounded corner,
- - <0.0 Radius of a cut corner.
+- 0.0 Sharp corner,
+- >0.0 Radius of a rounded corner,
+- <0.0 Radius of a cut corner.
 
 ### color
+
 A 4D red, green, blue and alpha values. A `color` can be transformed like a `vector3`, in this
 case the alpha value is ignored and copied into the result.
 
 For more information see: [color](color.md).
 
 ### rectangle
+
 A `rectangle` is a closed plane in three dimensions.
 
 A `rectangle` can be transformed like a `point3`.
@@ -60,22 +65,23 @@ It should be implemented as a `point3` in the left-bottom corner and two `vector
 However it is currently implemented as 4 points one for each corner.
 
 ### axis_aligned_rectangle
+
 The `axis_aligned_rectangle` class is a 2D axis-aligned rectangle.
 
 When transforming an axis aligned rectangle in 3D or with rotation the result will be a normal `rectangle`.
 A rectangle can be converted back to an axis_aligned_rectangle, as a bounding rectangle around the transformed rectangle.
 
 a axis_aligned_rectangle is implemented as a `f32x4` where:
- - x - left-bottom point x.
- - y - left-bottom point y.
- - z - right-top point x.
- - w - right-top point y.
 
+- x - left-bottom point x.
+- y - left-bottom point y.
+- z - right-top point x.
+- w - right-top point y.
 
-Transformation types
----------------------
+## Transformation types
 
 ### geo::identity
+
 An identity transform does not
 
 ### geo::translate<D>
@@ -83,8 +89,9 @@ An identity transform does not
 ### geo::scale<D>
 
 ### geo::rotate<D>
- 
+
 ### geo::matrix<D>
+
 The `mat` class is a 4x4 homogeneous transformation matrix in column-major
 order. Internally this a `vec` for each column.
 
@@ -92,21 +99,20 @@ Vector * matrix multiplications are performed as if the vector is a column.
 
 ### geo::transform
 
+## Coordinates
 
-
-
-Coordinates
------------
 All origins (0, 0, 0) are at the bottom-left-far corner. With the x-axis pointing
 right, y-axis pointing up, z-axis pointing near.
 
 This is true for:
- - Window
- - Images
- - Paths
- - Font-glyphs
+
+- Window
+- Images
+- Paths
+- Font-glyphs
 
 ### Window and Widget-surface coordinates
+
 The local coordinates in a window and widgets are in points.
 With the origin in the corner of the left bottom most point.
 
@@ -126,50 +132,59 @@ default 72 DPI. The ShapedText class will scale to 84 DPI automatically,
 further DPI scaling will be handled by the draw_context.
 
 ### Window depth
+
 Z-coordinate for a window is between 0.0 (far) to 100.0 (near).
 For better precision we use a reverse-z method, to combine
 1/z together with float with linear precision.
 
- - The window-widget is set to depth 0.0.
- - Each nested widget, which needs to draw itself, is 1.0 nearer.
- - Widgets which extends across other widgets, such as a combo-box-widget
+- The window-widget is set to depth 0.0.
+- Each nested widget, which needs to draw itself, is 1.0 nearer.
+- Widgets which extends across other widgets, such as a combo-box-widget
    will be 25.0 nearer.
 
 ### Image coordinates
+
 The coordinates in a image are in pixels. With the center of the left bottom
 pixel having the coordinates (0.5, 0.5).
 
 ### Path coordinates
+
 The coordinates in a path are free from scale and origin, when rendering a
 path to an image, the path should be first be transformed to image coordinates.
 
 ### Glyph/Font coordinates
+
 Glyph coordinates are in the number of Em units.
 X-axis pointing right, Y-axis pointing up.
 The origin (0,0) is on the crossing of the base line and left side bearing.
 Vertices of front faces are specified in counter clockwise order.
 
 ## Corners
+
 Corners are enumerated as follows:
- - 0: near bottom left
- - 1: near bottom right
- - 2: near top left
- - 3: near top right
- - 4: far bottom left
- - 5: far bottom right
- - 6: far top left
- - 7: far top right
+
+- 0: near bottom left
+- 1: near bottom right
+- 2: near top left
+- 3: near top right
+- 4: far bottom left
+- 5: far bottom right
+- 6: far top left
+- 7: far top right
 
 When corners are passing as 4D vectors:
- - x = bottom-left
- - y = bottom-right
- - z = top-left
- - w = top-right
+
+- x = bottom-left
+- y = bottom-right
+- z = top-left
+- w = top-right
 
 ## Triangles
+
 A front facing triangle has the vertex ordered in counter-clockwise direction.
 
 ## Quads
+
 Quads are defined as two front facing triangles.
 The vertex index order is: 0, 1, 2, 2, 1, 3
 
@@ -183,4 +198,3 @@ As illustrated below:
 v    \ |
 0 ---> 1
 ```
-

--- a/docs/gui_system.md
+++ b/docs/gui_system.md
@@ -27,12 +27,16 @@ auto callback = button->subscribe([]{ foo(); });
 ```
 
 ### Checkbox
+
 The checkbox is configured with a true-value and a false-value, to match
-with the observed value; When the observed value is equal to:
- - **true-value**: A checkmark is shown inside the box and the
-   true\_label is shown to the right of the box.
- - **false-value**: The box is empty and the
-   false\_label is shown to the right of the box.
+with the observed value.
+
+When the observed value is equal to:
+
+ - **true-value**: a checkmark is shown inside the box and the
+   true\_label is shown to the right of the box,
+ - **false-value**: the box is empty and the
+   false\_label is shown to the right of the box,
  - neither: a dash is shown inside the box and the
    other\_label is shown to the right of the box.
 
@@ -55,6 +59,7 @@ button->other_label = l10n("other");
 ```
 
 ### Radio button
+
 In ttauri a set of radio buttons are a set of `tt::radio_button_widget`s.
 Each of the widgets in a set observe the same value and each widget is configured with
 a different true-value.

--- a/docs/information_reporting.md
+++ b/docs/information_reporting.md
@@ -1,37 +1,41 @@
-# Information reporting
+Information reporting
+=====================
 
-## Exceptions
+Exceptions
+----------
 
 TTauri will internally use many of the exceptions of the standard library.
 The library also includes its own exceptions. These exceptions work the same
 as standard library exceptions, except that the constructor works like
 std::format for easy construction of the 'what' string.
 
-- `tt::parse_error`: Files and protocols are under control of users and
+ - `tt::parse_error`: Files and protocols are under control of users and
    for security reasons it is important to code it defensively with many
    checks. These checks should throw exceptions a `tt::parse_error`.
    For reasons of denial of service errors in a file or protocol
    should never cause the application to crash or terminate.
-- `tt::operation_error`: Thrown when an operation on dynamic types are invalid.
+ - `tt::operation_error`: Thrown when an operation on dynamic types are invalid.
    This can happen when processing a language.
-- `tt::io_error`: Thrown when there is an I/O error.
-- `tt::gui_error`: Exception thrown when errors happen when calling graphic
+ - `tt::io_error`: Thrown when there is an I/O error.
+ - `tt::gui_error`: Exception thrown when errors happen when calling graphic
    APIs like Vulkan.
-- `tt::url_error`: Thrown on invalid URLs.
+ - `tt::url_error`: Thrown on invalid URLs.
 
-## Assertions
+Assertions
+----------
 
-- `tt_assert()`: Used to check for programming errors, in both debug and
+ - `tt_assert()`: Used to check for programming errors, in both debug and
    release builds.
-- `tt_axiom()`: Used to check for programming error in debug builds.
+ - `tt_axiom()`: Used to check for programming error in debug builds.
    In release builds the expression is used as a hint to the optimizer.
-- `tt_no_default()`: Used in places that should not be reachable,
+ - `tt_no_default()`: Used in places that should not be reachable,
    such as default labels of switch statements, or unreachable else
    blocks.
-- `tt_static_no_default()`: Used in unreachable constexpr else blocks.
-- `tt_not_implemented()`: Added when functionality should exist, but
+ - `tt_static_no_default()`: Used in unreachable constexpr else blocks.
+ - `tt_not_implemented()`: Added when functionality should exist, but
 
-## Counting
+Counting
+--------
 
 The `tt::increment_counter()` is used to increment a global counter.
 The template parameter is a string literal.
@@ -40,7 +44,8 @@ This function is designed for low latency and uses an atomic 64 bit counter.
 On the first count the counter is registered with the statistics logging
 system which logs the counter value each minute.
 
-## Tracing
+Tracing
+-------
 
 Instantiating a `tt::trace` class starts a trace. A trace will track the amount
 if time is spend inside the trace. Extra information may be included with
@@ -56,7 +61,8 @@ When `tt::trace_record()` is called within a trace all information about
 the current trace and any encapsulating traces are logged. `tt::trace_record()`
 is implicitly called when using `tt_log_error()`.
 
-## Logging
+Logging
+-------
 
 The logging system is for logs textual messages to a console or a file.
 It is the main system of high level debugging.
@@ -67,26 +73,26 @@ however the actual formatting is delayed and offloaded to the logger thread.
 
 Logging is wait-free, unless:
 
-- the ring buffer is full which causes the logging to block.
-- objects passed as argument allocate on copy.
-- All the objects together occupies more bytes than the message
+ - the ring buffer is full which causes the logging to block.
+ - objects passed as argument allocate on copy.
+ - All the objects together occupies more bytes than the message
    in the ring buffer 224 bytes, which causes an allocation.
 
 The following log functions are available:
 
-- `tt_log_debug()`: Logging debug information, which is used while developing
+ - `tt_log_debug()`: Logging debug information, which is used while developing
    the application.
-- `tt_log_info()`: Log information messages, which is used while debugging
+ - `tt_log_info()`: Log information messages, which is used while debugging
    an installation of the application.
-- `tt_log_statistics()`: Statistics information logged by the counter and
+ - `tt_log_statistics()`: Statistics information logged by the counter and
    tracing system.
-- `tt_log_trace()`: Information logged by the tracing system when _recording_
+ - `tt_log_trace()`: Information logged by the tracing system when _recording_
    a trace.
-- `tt_log_audit()`: Log audit information, for data that must be logged
+ - `tt_log_audit()`: Log audit information, for data that must be logged
    for security, business or regulatory reasons.
-- `tt_log_warning()`: Warnings are where something was wrong but the application
+ - `tt_log_warning()`: Warnings are where something was wrong but the application
    was able to fully recover from it.
-- `tt_log_error()`: An error occurred which causes the application to not be
+ - `tt_log_error()`: An error occurred which causes the application to not be
    fully functional but still able to operate. This will also call `tt::trace_record()`.
-- `tt_log_fatal()`: An unrecoverable error has occurred and the application has
+ - `tt_log_fatal()`: An unrecoverable error has occurred and the application has
    to terminate. This will cause the application to abort.

--- a/docs/information_reporting.md
+++ b/docs/information_reporting.md
@@ -1,41 +1,38 @@
-Information reporting
-=====================
+# Information reporting
 
-Exceptions
-----------
+## Exceptions
+
 TTauri will internally use many of the exceptions of the standard library.
 The library also includes its own exceptions. These exceptions work the same
 as standard library exceptions, except that the constructor works like
 std::format for easy construction of the 'what' string.
 
- - `tt::parse_error`: Files and protocols are under control of users and
+- `tt::parse_error`: Files and protocols are under control of users and
    for security reasons it is important to code it defensively with many
    checks. These checks should throw exceptions a `tt::parse_error`.
    For reasons of denial of service errors in a file or protocol
    should never cause the application to crash or terminate.
- - `tt::operation_error`: Thrown when an operation on dynamic types are invalid.
+- `tt::operation_error`: Thrown when an operation on dynamic types are invalid.
    This can happen when processing a language.
- - `tt::io_error`: Thrown when there is an I/O error.
- - `tt::gui_error`: Exception thrown when errors happen when calling graphic
+- `tt::io_error`: Thrown when there is an I/O error.
+- `tt::gui_error`: Exception thrown when errors happen when calling graphic
    APIs like Vulkan.
- - `tt::url_error`: Thrown on invalid URLs.
+- `tt::url_error`: Thrown on invalid URLs.
 
-Assertions
-----------
+## Assertions
 
- - `tt_assert()`: Used to check for programming errors, in both debug and
+- `tt_assert()`: Used to check for programming errors, in both debug and
    release builds.
- - `tt_axiom()`: Used to check for programming error in debug builds.
+- `tt_axiom()`: Used to check for programming error in debug builds.
    In release builds the expression is used as a hint to the optimizer.
- - `tt_no_default()`: Used in places that should not be reachable,
+- `tt_no_default()`: Used in places that should not be reachable,
    such as default labels of switch statements, or unreachable else
    blocks.
- - `tt_static_no_default()`: Used in unreachable constexpr else blocks.
- - `tt_not_implemented()`: Added when functionality should exist, but
-   
+- `tt_static_no_default()`: Used in unreachable constexpr else blocks.
+- `tt_not_implemented()`: Added when functionality should exist, but
 
-Counting
---------
+## Counting
+
 The `tt::increment_counter()` is used to increment a global counter.
 The template parameter is a string literal.
 
@@ -43,24 +40,24 @@ This function is designed for low latency and uses an atomic 64 bit counter.
 On the first count the counter is registered with the statistics logging
 system which logs the counter value each minute.
 
-Tracing
--------
+## Tracing
+
 Instantiating a `tt::trace` class starts a trace. A trace will track the amount
-if time is spend inside the trace. And extra information may be included with
+if time is spend inside the trace. Extra information may be included with
 the trace for debugging purpose.
 
 A lot of care is taken for this function to be efficient and may be used
 in a lot of places in the code. It uses thread\_local storage. And it
-will be slightly more expensiving than counting.
+will be slightly more expensive than counting.
 
 The average and accumulated time spend inside a trace is logged every minute.
 
 When `tt::trace_record()` is called within a trace all information about
-he current trace and any encapsulating traces are logged. `tt::trace_record()`
-is implicently called when using `tt_log_error()`.
+the current trace and any encapsulating traces are logged. `tt::trace_record()`
+is implicitly called when using `tt_log_error()`.
 
-Logging
--------
+## Logging
+
 The logging system is for logs textual messages to a console or a file.
 It is the main system of high level debugging.
 
@@ -69,26 +66,27 @@ either counting or tracing. The logger functions work like std::format
 however the actual formatting is delayed and offloaded to the logger thread.
 
 Logging is wait-free, unless:
- - the ring buffer is full which causes the logging to block.
- - objects passed as argument allocate on copy.
- - All the objects together occupies more bytes than the message
+
+- the ring buffer is full which causes the logging to block.
+- objects passed as argument allocate on copy.
+- All the objects together occupies more bytes than the message
    in the ring buffer 224 bytes, which causes an allocation.
 
 The following log functions are available:
- - `tt_log_debug()`: Logging debug information, which is used while developing
-   the application.
- - `tt_log_info()`: Log information messages, which is used while debugging
-   an installation of the application.
- - `tt_log_statistics()`: Statistics information logged by the counter and
-   tracing system.
- - `tt_log_trace()`: Information logged by the tracing system when _recording_
-   a trace.
- - `tt_log_audit()`: Log audit information, for data that must be logged
-   for security, business or regulatory reasons.
- - `tt_log_warning()`: Warnings are where something was wrong but the application
-   was able to fully recover from it.
- - `tt_log_error()`: An error occurred which causes the application to not be
-   fully functional but still able to operate. This will also call `tt::trace_record()`
- - `tt_log_fatal()`: An unrecoverable error has occurred and the application has
-   to terminate. This will cause the application to abort.
 
+- `tt_log_debug()`: Logging debug information, which is used while developing
+   the application.
+- `tt_log_info()`: Log information messages, which is used while debugging
+   an installation of the application.
+- `tt_log_statistics()`: Statistics information logged by the counter and
+   tracing system.
+- `tt_log_trace()`: Information logged by the tracing system when _recording_
+   a trace.
+- `tt_log_audit()`: Log audit information, for data that must be logged
+   for security, business or regulatory reasons.
+- `tt_log_warning()`: Warnings are where something was wrong but the application
+   was able to fully recover from it.
+- `tt_log_error()`: An error occurred which causes the application to not be
+   fully functional but still able to operate. This will also call `tt::trace_record()`
+- `tt_log_fatal()`: An unrecoverable error has occurred and the application has
+   to terminate. This will cause the application to abort.

--- a/docs/information_reporting.md
+++ b/docs/information_reporting.md
@@ -87,6 +87,6 @@ The following log functions are available:
 - `tt_log_warning()`: Warnings are where something was wrong but the application
    was able to fully recover from it.
 - `tt_log_error()`: An error occurred which causes the application to not be
-   fully functional but still able to operate. This will also call `tt::trace_record()`
+   fully functional but still able to operate. This will also call `tt::trace_record()`.
 - `tt_log_fatal()`: An unrecoverable error has occurred and the application has
    to terminate. This will cause the application to abort.

--- a/docs/main_page.md
+++ b/docs/main_page.md
@@ -1,14 +1,17 @@
-# TTauri {#mainpage}
+TTauri {#mainpage}
+==================
 
 TTauri is a cross platform C++ GUI library.
 
-## Subsystems
+Subsystems
+----------
 
 - [Information Reporting](information_reporting.md): exceptions, assertions,
    logging, counting and tracing.
 - [Geometry](geometry.md): `vector`, `geo::point`, `tt::geo::extent`, rectangle, axis-aligned rectangle, translate, scale, rotate, matrix.
 
-## Features
+Features
+--------
 
 ### Box drawing
 
@@ -44,30 +47,31 @@ it is not able to correctly draw overlapping glyphs. Since
 the shader will always revert to the background drawn by the
 previous sub-pass.
 
-## Performance
+Performance
+-----------
 
 TTauri is designed for low latency interactive applications.
 
 For this reason we have the following design considerations:
 
-- Widgets need to be able to animate at 60 fps.
-- CPU and GPU usage when drawing at 60 fps need to remain low.
-- Monitored data needs to be reflected in the user interface
+ - Widgets need to be able to animate at 60 fps.
+ - CPU and GPU usage when drawing at 60 fps need to remain low.
+ - Monitored data needs to be reflected in the user interface
    with at most one frame delay.
-- During drawing the widget can use predictive algorithms to
+ - During drawing the widget can use predictive algorithms to
    determine what should be shown to the user at the display time.
    When for example showing the current time on the display.
 
 The following
 
-- Use game-like redraw loop running at the current system's
+ - Use game-like redraw loop running at the current system's
    frame rate. Immediately reflecting updated data. And caching
    size-constraining, layout, text-shaping, and other expensive
    pre-draw operations.
-- Partial drawing, widgets will only draw anything that falls
+ - Partial drawing, widgets will only draw anything that falls
    within the current scissor rectangle. The scissor rectangle
    allows the GPU to discard drawing outside it to improve
    drawing speed.
-- All drawing is done by passing vertices to different
+ - All drawing is done by passing vertices to different
    shaders for GPU accelerated drawing of: flat-polygons,
    rounded-rectangles, pixmap-images and text-glyphs.

--- a/docs/main_page.md
+++ b/docs/main_page.md
@@ -62,7 +62,7 @@ The following
 
 - Use game-like redraw loop running at the current system's
    frame rate. Immediately reflecting updated data. And caching
-   size-constrainng, layout, text-shaping, and other expensive
+   size-constraining, layout, text-shaping, and other expensive
    pre-draw operations.
 - Partial drawing, widgets will only draw anything that falls
    within the current scissor rectangle. The scissor rectangle

--- a/docs/main_page.md
+++ b/docs/main_page.md
@@ -1,78 +1,73 @@
-TTauri {#mainpage}
-==================
+# TTauri {#mainpage}
 
 TTauri is a cross platform C++ GUI library.
 
-Subsystems
-----------
+## Subsystems
 
- - [Information Reporting](information_reporting.md): exceptions, assertions,
+- [Information Reporting](information_reporting.md): exceptions, assertions,
    logging, counting and tracing.
- - [Geometry](geometry): `vector`, `geo::point`, `tt::geo::extent`, rectangle, axis-aligned rectangle,
-   translate, scale, rotate, matrix.
+- [Geometry](geometry.md): `vector`, `geo::point`, `tt::geo::extent`, rectangle, axis-aligned rectangle, translate, scale, rotate, matrix.
 
-Features
---------
+## Features
 
 ### Box drawing
+
 Most drawing is done through the box-drawing shader.
 The box-drawing shader can draw an anti-aliased box with:
 
- * a background color mixed from the 4 vertices,
- * a border color mixed from the 4 vertices,
- * a border width,
- * a corner radius for each corner, and
- * a clipping rectangle to cut part of the box.
+- a background color mixed from the 4 vertices,
+- a border color mixed from the 4 vertices,
+- a border width,
+- a corner radius for each corner, and
+- a clipping rectangle to cut part of the box.
 
 This primitive can be used to draw different shapes, like:
 
- * normal rectangles,
- * rounded rectangles,
- * slots, and
- * circles.
+- normal rectangles,
+- rounded rectangles,
+- slots, and
+- circles.
 
 ### Text drawing
+
 Glyphs are drawn by the GPU using a signed-distance-field shader.
 This shader is able to render glyphs with subpixel-anti-aliasing
 without using a post processing filter.
 
-Glyphs are lazilly and asynchronous added to the texture-atlas
+Glyphs are lazily and asynchronous added to the texture-atlas
 when needed. By adding the glyphs as signed distance fields to
 the texture atlas a glyph needs to be added only once to be usable
 for displaying at any size.
 
 Due to the shader having to perform subpixel-compositing,
 it is not able to correctly draw overlapping glyphs. Since
-the shader will always rever to the background drawn by the
+the shader will always revert to the background drawn by the
 previous sub-pass.
 
-Performance
------------
+## Performance
+
 TTauri is designed for low latency interactive applications.
 
 For this reason we have the following design considerations:
 
- * Widgets need to be able to animate at 60 fps.
- * CPU and GPU usage when drawing at 60 fps need to remain low.
- * Monitorred data needs to be reflected in the user interface
+- Widgets need to be able to animate at 60 fps.
+- CPU and GPU usage when drawing at 60 fps need to remain low.
+- Monitored data needs to be reflected in the user interface
    with at most one frame delay.
- * During drawing the widget can use predictive algorithms to
+- During drawing the widget can use predictive algorithms to
    determine what should be shown to the user at the display time.
    When for example showing the current time on the display.
 
-The following 
+The following
 
- * Use game-like redraw loop running at the current system's
-   frame rate. Immediatly reflecting updated data. And caching
+- Use game-like redraw loop running at the current system's
+   frame rate. Immediately reflecting updated data. And caching
    size-constrainng, layout, text-shaping, and other expensive
    pre-draw operations.
- * Partial drawing, widgets will only draw anything that falls
+- Partial drawing, widgets will only draw anything that falls
    within the current scissor rectangle. The scissor rectangle
    allows the GPU to discard drawing outside it to improve
    drawing speed.
- * All drawing is done by passing vertices to different
-   shaders for GPU accellerated drawing of: flat-polygons,
+- All drawing is done by passing vertices to different
+   shaders for GPU accelerated drawing of: flat-polygons,
    rounded-rectangles, pixmap-images and text-glyphs.
-
-
-

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -19,7 +19,7 @@ _key_=_value_   | Update the value
 _key_           | Show current value
 !_key_          | Set a value to its default
 
-The order of operations are:
+The order of operations is:
 
  1. Load application preferences
  2. Handle all arguments left-to-right

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,9 +1,11 @@
-# Application Preferences
+Application Preferences
+=======================
 
 The preferences of an application are loaded and saved into a JSON file.
 Whenever a configuration values is modified the preferences are automatically saved.
 
-## Command Line
+Command Line
+------------
 
 The command line can be used to update the preferences.
 

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,26 +1,26 @@
-Application Preferences
-=======================
+# Application Preferences
 
 The preferences of an application are loaded and saved into a JSON file.
 Whenever a configuration values is modified the preferences are automatically saved.
 
-Command Line
-------------
+## Command Line
+
 The command line can be used to update the preferences.
 
-  Argument        | Description
- :--------------- |:-------------
-  --help          | Show help information, implies --list and --exit
-  --list          | Show list of current and default values
-  --exit[=_code_] | Exit the application after handling all arguments.
-  --reset         | Reset the preferences to the default values.
-  --load=_path_   | Load a named preferences file and use it to update the preferences
-  --save=_path_   | Save the current preferences to a named preferences file
-  _key_=_value_   | Update the value
-  _key_           | Show current value
-  !_key_          | Set a value to its default
+Argument        | Description
+----------------|:------------------------------------------------------------------
+--help          | Show help information, implies --list and --exit
+--list          | Show list of current and default values
+--exit[=_code_] | Exit the application after handling all arguments.
+--reset         | Reset the preferences to the default values.
+--load=_path_   | Load a named preferences file and use it to update the preferences
+--save=_path_   | Save the current preferences to a named preferences file
+_key_=_value_   | Update the value
+_key_           | Show current value
+!_key_          | Set a value to its default
 
 The order of operations are:
+
  1. Load application preferences
  2. Handle all arguments left-to-right
  3. Optionally exit the application

--- a/docs/render_architecture.md
+++ b/docs/render_architecture.md
@@ -2,14 +2,16 @@
 XXX Depth buffer can be used as per-primitive clipping/stencil buffer.
 
 # Render architecture
+
 Vulkan is used as the backend for rendering windows.
+
 
 ```
 
      +---------+
      | Window  |
      +---------+
-          |      
+          |
       Tone Mapper
          | |
          | +---------------+
@@ -35,19 +37,17 @@ Vulkan is used as the backend for rendering windows.
                  |  Atlas  |
                  +---------+
 
-
-
-
-
 ```
 
 ## Window
+
 The swap-chain of the window will consist of RGBA images with alpha set to 1.
 
 The window may either have the sRGB color space, or the extended-float16-sRGB
 color space.
 
 ## Single pass, five sub-passes.
+
 The whole render architecture is using a single pass with five sub-passes.
 
 By using a single pass the shader of the sub-passes are able to efficiently
@@ -60,36 +60,37 @@ HDR/WCG (High Dynamic Range / Wide Color Gamut). The frame buffer also
 includes a depth image.
 
 The five sub-passes are:
- - Flat Shader  - Render simple non-anti-aliased quads.
- - Box Shader   - Render anti-aliased rectangles with rounded corners.
- - Image Shader - Render anti-aliased texture mapped quads.
- - SDF Shader   - Render text-glyphs with sub-pixel-anti-aliasing.
- - Tone Mapper  - Convert HDR/WCG image to the reduced range of the display.
+
+- Flat Shader  - Render simple non-anti-aliased quads.
+- Box Shader   - Render anti-aliased rectangles with rounded corners.
+- Image Shader - Render anti-aliased texture mapped quads.
+- SDF Shader   - Render text-glyphs with sub-pixel-anti-aliasing.
+- Tone Mapper  - Convert HDR/WCG image to the reduced range of the display.
 
 ## Text Shaping
 
 Steps of text-shaping:
- - Start: with a list of style-graphemes in logical ordering. The style-grapheme contains the
+
+- Start: with a list of style-graphemes in logical ordering. The style-grapheme contains the
    Unicode-NFC and each grapheme as a style. Latin automatic ligatures such as 'ffi' are illegal
    and should never be composed into a single grapheme.
- - Unicode-bidirectional-algorithm: This will put the list of graphemes in
+- Unicode-bidirectional-algorithm: This will put the list of graphemes in
    left-to-right render order. The new graphemes are in the form style-index-grapheme, here
    the index points back to the original order.
- - Glyph lookup: Each style-index-grapheme is looked up and converted into a set of font-glyph-size-color-index.
+- Glyph lookup: Each style-index-grapheme is looked up and converted into a set of font-glyph-size-color-index.
    The search-priority algorithm will be described below.
- - Glyph morphing: Process a sequence of glyphs from the same font through the font's glyph morphing algorithms.
+- Glyph morphing: Process a sequence of glyphs from the same font through the font's glyph morphing algorithms.
    The resulting font-glyph-size-color-index may contain fewer or more glyphs due to this morphing.
    This is also the place where ligatures like 'ffi' are constructed by the font itself.
- - Line breaking: based on a given width, extra line breaks are added to the text.
- - Advance and kerning: Each glyph is assigned a screen position based on the advance and kerning algorithms of
+- Line breaking: based on a given width, extra line breaks are added to the text.
+- Advance and kerning: Each glyph is assigned a screen position based on the advance and kerning algorithms of
    the font.
- - Output 1: A list of vertex-points with screen-, texture- and color coordinates. And a index back to the original
+- Output 1: A list of vertex-points with screen-, texture- and color coordinates. And a index back to the original
    graphemes in logical ordering.
- - Output 2: A list of caret locations, by index.
-    - It is possible for a single index to have up to two locations, due to left-to-right and right-to-left switching.
-    - It is possible to use this list to find the nearest caret location to the mouse cursor.
-    - The caret location list also contains the caret height and slant. 
-
+- Output 2: A list of caret locations, by index.
+  - It is possible for a single index to have up to two locations, due to left-to-right and right-to-left switching.
+  - It is possible to use this list to find the nearest caret location to the mouse cursor.
+  - The caret location list also contains the caret height and slant.
 
 ### Glyph Lookup algorithm
 
@@ -107,25 +108,24 @@ he returned fonts are then matched with the font-style of the grapheme.
 This font is cached based on the style, and any code point is first checked with this
 cached font. If the code point is not found then the full lookup is done.
 
-
-
 ### Font styles
+
 A font style is a 32 bit description of how a grapheme should
 be displayed. It is only 32 bit so that it is accompanied with each
 attributed-grapheme.
 
 A font-style has the following characteristics:
- 
-  Bits | Name            | Description
- -----:|:--------------- |:-------------------------------------
- 24:31 | Super-Family ID | Super font family id 0-255.
-    23 | Serif           |
-    22 | Monospaced      | Serif + Monospace = Slab
-    21 | Italic          | Italic / Oblique
-    20 | Condensed       |
- 16:19 | Weight          | See weight table below.
-  8:15 | Optical size    | Design size in 0-255 pt
-  0: 7 | Color index     |
+
+ Bits | Name            | Description
+-----:|:----------------|:---------------------------
+24:31 | Super-Family ID | Super font family id 0-255.
+   23 | Serif           |
+   22 | Monospaced      | Serif + Monospace = Slab
+   21 | Italic          | Italic / Oblique
+   20 | Condensed       |
+16:19 | Weight          | See weight table below.
+ 8:15 | Optical size    | Design size in 0-255 pt
+ 0: 7 | Color index     |
 
 The characteristics are read from the 'feat' table or parsed from the
 filename.
@@ -136,43 +136,50 @@ should be ignored in such a case.
 
 Weight table:
 
-  Code | Value  | Description
- -----:| ------:|:------------
-     0 |    100 | Thin / Hairline
-     1 |    200 | Ultra-light / Extra-light
-     2 |    300 | Light
-     3 |    400 | Normal / Regular
-     4 |    500 | Medium
-     5 |    600 | Semi-bold / Demi-bold
-     6 |    700 | Bold
-     7 |    800 | Extra-bold / Ultra-bold
-     8 |    900 | Heavy / Black
-     9 |    950 | Extra-black / Ultra-black
-
+Code | Value | Description
+----:|------:|:-------------------------
+   0 |   100 | Thin / Hairline
+   1 |   200 | Ultra-light / Extra-light
+   2 |   300 | Light
+   3 |   400 | Normal / Regular
+   4 |   500 | Medium
+   5 |   600 | Semi-bold / Demi-bold
+   6 |   700 | Bold
+   7 |   800 | Extra-bold / Ultra-bold
+   8 |   900 | Heavy / Black
+   9 |   950 | Extra-black / Ultra-black
 
 ## Themes
+
 A theme consists of predefined colors, fonts and button shapes.
 A theme is loaded from a json file. The theme directory is scanned for all themes
 and from the preferences the user can select the current theme at runtime.
 
 ### Colors
+
 #### Accent Color
+
 #### Semantic Color
+
 #### Custom Color
+
 Custom colors are for application specific widgets. These colors may also be modified
 by the application at runtime. For example an audio application may use custom colors
 for drawing the audio level meters.
 
 ### Font Styles
+
 ### Button shapes
 
 ## Box Pipeline
+
 The box-pipeline is designed to draw axis-aligned quads with:
- - A fill color.
- - An anti-aliases border of a certain thickness and color.
- - An drop shadow around the border of a certain color.
- - An inlay shadow inside the border of a certain color.
- - Rounded and cut corners.
+
+- A fill color.
+- An anti-aliases border of a certain thickness and color.
+- An drop shadow around the border of a certain color.
+- An inlay shadow inside the border of a certain color.
+- Rounded and cut corners.
 
 By using "texture" coordinates the fragment shader knows the distance towards an edge.
 Together with a factor to convert the texture coordinate to pixel distance from

--- a/docs/render_architecture.md
+++ b/docs/render_architecture.md
@@ -1,7 +1,8 @@
 
 XXX Depth buffer can be used as per-primitive clipping/stencil buffer.
 
-# Render architecture
+Render architecture
+===================
 
 Vulkan is used as the backend for rendering windows.
 
@@ -39,14 +40,16 @@ Vulkan is used as the backend for rendering windows.
 
 ```
 
-## Window
+Window
+------
 
 The swap-chain of the window will consist of RGBA images with alpha set to 1.
 
 The window may either have the sRGB color space, or the extended-float16-sRGB
 color space.
 
-## Single pass, five sub-passes.
+Single pass, five sub-passes
+-----------------------------
 
 The whole render architecture is using a single pass with five sub-passes.
 
@@ -61,36 +64,37 @@ includes a depth image.
 
 The five sub-passes are:
 
-- Flat Shader  - Render simple non-anti-aliased quads.
-- Box Shader   - Render anti-aliased rectangles with rounded corners.
-- Image Shader - Render anti-aliased texture mapped quads.
-- SDF Shader   - Render text-glyphs with sub-pixel-anti-aliasing.
-- Tone Mapper  - Convert HDR/WCG image to the reduced range of the display.
+ - Flat Shader  - Render simple non-anti-aliased quads.
+ - Box Shader   - Render anti-aliased rectangles with rounded corners.
+ - Image Shader - Render anti-aliased texture mapped quads.
+ - SDF Shader   - Render text-glyphs with sub-pixel-anti-aliasing.
+ - Tone Mapper  - Convert HDR/WCG image to the reduced range of the display.
 
-## Text Shaping
+Text Shaping
+------------
 
 Steps of text-shaping:
 
-- Start: with a list of style-graphemes in logical ordering. The style-grapheme contains the
+ - Start: with a list of style-graphemes in logical ordering. The style-grapheme contains the
    Unicode-NFC and each grapheme as a style. Latin automatic ligatures such as 'ffi' are illegal
    and should never be composed into a single grapheme.
-- Unicode-bidirectional-algorithm: This will put the list of graphemes in
+ - Unicode-bidirectional-algorithm: This will put the list of graphemes in
    left-to-right render order. The new graphemes are in the form style-index-grapheme, here
    the index points back to the original order.
-- Glyph lookup: Each style-index-grapheme is looked up and converted into a set of font-glyph-size-color-index.
+ - Glyph lookup: Each style-index-grapheme is looked up and converted into a set of font-glyph-size-color-index.
    The search-priority algorithm will be described below.
-- Glyph morphing: Process a sequence of glyphs from the same font through the font's glyph morphing algorithms.
+ - Glyph morphing: Process a sequence of glyphs from the same font through the font's glyph morphing algorithms.
    The resulting font-glyph-size-color-index may contain fewer or more glyphs due to this morphing.
    This is also the place where ligatures like 'ffi' are constructed by the font itself.
-- Line breaking: based on a given width, extra line breaks are added to the text.
-- Advance and kerning: Each glyph is assigned a screen position based on the advance and kerning algorithms of
+ - Line breaking: based on a given width, extra line breaks are added to the text.
+ - Advance and kerning: Each glyph is assigned a screen position based on the advance and kerning algorithms of
    the font.
-- Output 1: A list of vertex-points with screen-, texture- and color coordinates. And a index back to the original
+ - Output 1: A list of vertex-points with screen-, texture- and color coordinates. And a index back to the original
    graphemes in logical ordering.
-- Output 2: A list of caret locations, by index.
-  - It is possible for a single index to have up to two locations, due to left-to-right and right-to-left switching.
-  - It is possible to use this list to find the nearest caret location to the mouse cursor.
-  - The caret location list also contains the caret height and slant.
+ - Output 2: A list of caret locations, by index.
+   - It is possible for a single index to have up to two locations, due to left-to-right and right-to-left switching.
+   - It is possible to use this list to find the nearest caret location to the mouse cursor.
+   - The caret location list also contains the caret height and slant.
 
 ### Glyph Lookup algorithm
 
@@ -149,7 +153,8 @@ Code | Value | Description
    8 |   900 | Heavy / Black
    9 |   950 | Extra-black / Ultra-black
 
-## Themes
+Themes
+------
 
 A theme consists of predefined colors, fonts and button shapes.
 A theme is loaded from a json file. The theme directory is scanned for all themes
@@ -171,15 +176,16 @@ for drawing the audio level meters.
 
 ### Button shapes
 
-## Box Pipeline
+Box Pipeline
+------------
 
 The box-pipeline is designed to draw axis-aligned quads with:
 
-- A fill color.
-- An anti-aliases border of a certain thickness and color.
-- An drop shadow around the border of a certain color.
-- An inlay shadow inside the border of a certain color.
-- Rounded and cut corners.
+ - A fill color.
+ - An anti-aliases border of a certain thickness and color.
+ - An drop shadow around the border of a certain color.
+ - An inlay shadow inside the border of a certain color.
+ - Rounded and cut corners.
 
 By using "texture" coordinates the fragment shader knows the distance towards an edge.
 Together with a factor to convert the texture coordinate to pixel distance from

--- a/docs/text.md
+++ b/docs/text.md
@@ -1,6 +1,8 @@
-# Text
+Text
+====
 
-## FontBook initialization
+FontBook initialization
+-----------------------
 
 When the application is started a global FontBook is instanced.
 During the FontBook's instantiation it will fast-parse each TrueType
@@ -13,15 +15,15 @@ startup time.
 
 The following information gleamed during the fast-parse:
 
-- `name` Preferred Font family name; code-16 if available, otherwise code-1
-- `name` Preferred Font subfamily name: code-17 if available, otherwise code-2
-- `OS/2` Font weight
-- `OS/2` Regular/Italic
-- `OS/2` Serif/Sans-serif
-- `OS/2` Variable/Monospace
-- `OS/2` Regular/Condensed
-- `OS/2` Unicode ranges (as backup the `cmap` table may be parsed)
-- `OS/2` The height of `x` and `H` (as back the `glyf` table may be parsed)
+ - `name` Preferred Font family name; code-16 if available, otherwise code-1
+ - `name` Preferred Font subfamily name: code-17 if available, otherwise code-2
+ - `OS/2` Font weight
+ - `OS/2` Regular/Italic
+ - `OS/2` Serif/Sans-serif
+ - `OS/2` Variable/Monospace
+ - `OS/2` Regular/Condensed
+ - `OS/2` Unicode ranges (as backup the `cmap` table may be parsed)
+ - `OS/2` The height of `x` and `H` (as back the `glyf` table may be parsed)
 
 Each font family is assigned a FamilyID.
 Each font is assigned a FontID.
@@ -33,7 +35,8 @@ Each font will be assigned a list of fallback fonts for missing glyph lookup.
 Priority is given for fonts that start with the same font family name. For
 example "Arial Arabic" will be prioritized when the current font is "Arial"
 
-## Font selection
+Font selection
+--------------
 
 A FontVariant consists of a FontWeight+serif-flag. This allows a user to select a font
 family to draw a text with and emphasize fragments of the text using italic and bold.
@@ -42,18 +45,19 @@ There are a total of maximum 20 FontVariants for each FontFamilyID.
 
 Selecting a font to render a text is done in several steps:
 
-- A user select a font family name and a FontVariant.
-- The font family name is looked up in the FontBook and a FontFamilyID is
+ - A user select a font family name and a FontVariant.
+ - The font family name is looked up in the FontBook and a FontFamilyID is
    returned for a font that exists on the system which closely matches the
    requested family.
-- The FontFamilyID + FontVariant is looked up in the FontBook and a FontID
+ - The FontFamilyID + FontVariant is looked up in the FontBook and a FontID
    is returned for the variant the closely matches the requested variant that
    is available for that family.
-- A grapheme + FontID is looked up in the FontBook and a FontGlyphIDs is returned.
+ - A grapheme + FontID is looked up in the FontBook and a FontGlyphIDs is returned.
    The returned FontID may be of another font than requested if the glyphs where
    not available in the requested fonts.
 
-## Text shaping
+Text shaping
+------------
 
 ### Phases
 

--- a/docs/text.md
+++ b/docs/text.md
@@ -1,27 +1,27 @@
-Text
-====
+# Text
 
-FontBook initialization
------------------------
+## FontBook initialization
+
 When the application is started a global FontBook is instanced.
 During the FontBook's instantiation it will fast-parse each TrueType
 font in the operating system's font folder.
 
-During the fast-parse the 'name', 'OS/2' and optionally other tables
+During the fast-parse the `name`, `OS/2` and optionally other tables
 are read and then the font files are closed and memory is freed. This
 fast-parse is designed to be very fast to reduce impact on application
 startup time.
 
 The following information gleamed during the fast-parse:
- * 'name' Prefered Font family name; code-16 if available, otherwise code-1
- * 'name' Prefered Font subfamily name: code-17 if available, otherwise code-2
- * 'OS/2' Font weight
- * 'OS/2' Regular/Italic
- * 'OS/2' Serif/Sans-serif
- * 'OS/2' Variable/Monospace
- * 'OS/2' Regular/Condensed
- * 'OS/2' Unicode ranges (as backup the 'cmap' table may be parsed)
- * 'OS/2' The height of 'x' and 'H' (as back the 'glyf' table may be parsed)
+
+- `name` Preferred Font family name; code-16 if available, otherwise code-1
+- `name` Preferred Font subfamily name: code-17 if available, otherwise code-2
+- `OS/2` Font weight
+- `OS/2` Regular/Italic
+- `OS/2` Serif/Sans-serif
+- `OS/2` Variable/Monospace
+- `OS/2` Regular/Condensed
+- `OS/2` Unicode ranges (as backup the `cmap` table may be parsed)
+- `OS/2` The height of `x` and `H` (as back the `glyf` table may be parsed)
 
 Each font family is assigned a FamilyID.
 Each font is assigned a FontID.
@@ -33,56 +33,53 @@ Each font will be assigned a list of fallback fonts for missing glyph lookup.
 Priority is given for fonts that start with the same font family name. For
 example "Arial Arabic" will be prioritized when the current font is "Arial"
 
-Font selection
---------------
+## Font selection
+
 A FontVariant consists of a FontWeight+serif-flag. This allows a user to select a font
 family to draw a text with and emphasize fragments of the text using italic and bold.
 
 There are a total of maximum 20 FontVariants for each FontFamilyID.
 
 Selecting a font to render a text is done in several steps:
- * A user select a font family name and a FontVariant.
- * The font family name is looked up in the FontBook and a FontFamilyID is
+
+- A user select a font family name and a FontVariant.
+- The font family name is looked up in the FontBook and a FontFamilyID is
    returned for a font that exists on the system which closely matches the
    requested family.
- * The FontFamilyID + FontVariant is looked up in the FontBook and a FontID
+- The FontFamilyID + FontVariant is looked up in the FontBook and a FontID
    is returned for the variant the closely matches the requested variant that
    is available for that family.
- * A grapheme + FontID is looked up in the FontBook and a FontGlyphIDs is returned.
+- A grapheme + FontID is looked up in the FontBook and a FontGlyphIDs is returned.
    The returned FontID may be of another font than requested if the glyphs where
    not available in the requested fonts.
 
-Text shaping
-------------
+## Text shaping
 
 ### Phases
 
- 1. Given a text and a text-style; calculate the natural size of the text
-    - Lookup the glyphs and their width.
- 2. Given a maximum width fold the text; shape the text.
-    - Line wrap the text to fit the maximum width.
-    - Execute the Unicode bidirectional algorithm.
-    - Lookup glyphs that have been replaced.
-    - Morph glyphs such as font ligatures
-    - Calculate position of each glyph
- 3. Draw the text, possibly replacing the color
- 4. Given draw coordinates find character in the original text.
- 5. Given a character in the original text find a neighboring character on the screen.
+1. Given a text and a text-style; calculate the natural size of the text
+   - Lookup the glyphs and their width.
+2. Given a maximum width fold the text; shape the text.
+   - Line wrap the text to fit the maximum width.
+   - Execute the Unicode bidirectional algorithm.
+   - Lookup glyphs that have been replaced.
+   - Morph glyphs such as font ligatures
+   - Calculate position of each glyph
+3. Draw the text, possibly replacing the color
+4. Given draw coordinates find character in the original text.
+5. Given a character in the original text find a neighboring character on the screen.
 
 ### Sub-styles
+
 Sub-styles can be selected in-line in the text using the following Unicode code-points:
 
-  Code   | Name      | Common Style        | Description
- :-------|:--------- |:------------------- |:--------------------------
-  U+FDD0 | Regular   | Regular             | This is the default regular text
-  U+FDD1 | Emphasis  | Italic              | For different but not more or less important than regular text.
-  U+FDD2 | Strong    | Bold or red         | For important text like warnings.
-  U+FDD3 | Light     | Light or gray       | For less important text, like long explanations.
-  U+FDD4 | Code      | Monospaced          | For data, or examples of data.
-  U+FDD5 | Link      | Underlined and blue | For clickable links.
+Code   | Name     | Common Style        | Description
+-------|:---------|:--------------------|:---------------------------------------------------------------
+U+FDD0 | Regular  | Regular             | This is the default regular text
+U+FDD1 | Emphasis | Italic              | For different but not more or less important than regular text.
+U+FDD2 | Strong   | Bold or red         | For important text like warnings.
+U+FDD3 | Light    | Light or gray       | For less important text, like long explanations.
+U+FDD4 | Code     | Monospaced          | For data, or examples of data.
+U+FDD5 | Link     | Underlined and blue | For clickable links.
 
 These code-points are non-character code-point and are used internally of the TTauri library.
-
-
-
-

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,58 +1,62 @@
-# GUI Themes
+GUI Themes
+==========
 
-## Color Style
+Color Style
+-----------
 
 Each color style has a combination of attributes that should be used together:
 
-- Background-color
-- Foreground-color
-- Accent-color
-- Shadow-color
-- Focus-color: Color of a focus ring.
+ - Background-color
+ - Foreground-color
+ - Accent-color
+ - Shadow-color
+ - Focus-color: Color of a focus ring.
 
-## Text Style
+Text Style
+----------
 
 Styles:
 
-- Default
-- Dim
-- Bright
-- Heading
-- Help: For help text
-- Warning
-- Error
+ - Default
+ - Dim
+ - Bright
+ - Heading
+ - Help: For help text
+ - Warning
+ - Error
 
 Attributes:
 
-- Color-style
-- Font (uses foreground-color)
-- Font-size
-- Underline (uses accent-color)
-- Double-Underline (uses accent-color)
-- Strike-through (uses accent-color)
-- Wave (uses accent-color)
-- Drop shadow (uses shadow-color)
+ - Color-style
+ - Font (uses foreground-color)
+ - Font-size
+ - Underline (uses accent-color)
+ - Double-Underline (uses accent-color)
+ - Strike-through (uses accent-color)
+ - Wave (uses accent-color)
+ - Drop shadow (uses shadow-color)
 
-## GUI Element
+GUI Element
+-----------
 
 GUI Elements may be nested and should copy the color-palette from the parent.
 The use may configure user elements to have a different color-palette.
 
 Styles:
 
-- Default
-- Important
-- Compact: For use in panels
+ - Default
+ - Important
+ - Compact: For use in panels
 
 State:
 
-- Normal
-- Focus
-- Disabled
+ - Normal
+ - Focus
+ - Disabled
 
 Attributes:
 
-- Color-style
-- Text-style
-- Corner-radius
-- Corner-style
+ - Color-style
+ - Text-style
+ - Corner-radius
+ - Corner-style

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,55 +1,58 @@
 # GUI Themes
 
-
 ## Color Style
 
 Each color style has a combination of attributes that should be used together:
- * Background-color
- * Foreground-color
- * Accent-color
- * Shadow-color
- * Focus-color: Color of a focus ring.
+
+- Background-color
+- Foreground-color
+- Accent-color
+- Shadow-color
+- Focus-color: Color of a focus ring.
 
 ## Text Style
 
 Styles:
- * Default
- * Dim
- * Bright
- * Heading
- * Help: For help text
- * Warning
- * Error
+
+- Default
+- Dim
+- Bright
+- Heading
+- Help: For help text
+- Warning
+- Error
 
 Attributes:
- * Color-style
- * Font (uses foreground-color)
- * Font-size
- * Underline (uses accent-color)
- * Double-Underline (uses accent-color)
- * Strike-through (uses accent-color)
- * Wave (uses accent-color)
- * Drop shadow (uses shadow-color)
+
+- Color-style
+- Font (uses foreground-color)
+- Font-size
+- Underline (uses accent-color)
+- Double-Underline (uses accent-color)
+- Strike-through (uses accent-color)
+- Wave (uses accent-color)
+- Drop shadow (uses shadow-color)
 
 ## GUI Element
 
 GUI Elements may be nested and should copy the color-palette from the parent.
-The use may configure user elements to have a different color-palette. 
-
+The use may configure user elements to have a different color-palette.
 
 Styles:
- * Default
- * Important
- * Compact: For use in panels
+
+- Default
+- Important
+- Compact: For use in panels
 
 State:
- * Normal
- * Focus
- * Disabled
+
+- Normal
+- Focus
+- Disabled
 
 Attributes:
- * Color-style
- * Text-style
- * Corner-radius
- * Corner-style
 
+- Color-style
+- Text-style
+- Corner-radius
+- Corner-style

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,22 +1,23 @@
 # TTauri time handling.
 
 ## High resolution UTC.
-`hires_utc_clock` is a std::chrono clock. This is a clock with 1ns resolution, but its actual precission
-is based on the clock of the operating system:
- * POSIX `clock_gettime(CLOCK_REALTIME)`
- * Windows 10 `GetSystemTimeAsFileTime()`
- * macOS/iOS `gettimeofday()`
 
-During leap-seconds the UTC clock may slew or jump depending on how the operating system clock.
+`hires_utc_clock` is a std::chrono clock. This is a clock with 1ns resolution, but its actual precision
+is based on the clock of the operating system:
+
+- POSIX `clock_gettime(CLOCK_REALTIME)`
+- Windows 10 `GetSystemTimeAsFileTime()`
+- macOS/iOS `gettimeofday()`
+
+During leap-seconds the UTC clock may slew or jump depending on how the operating system clock operates.
 
 ## High performance Continues-UTC
-`hiperf_cutc_clock` is a std::chrono clock. This is a clock with 1ns resolution, but its actual precission
-is based on a CPU counter and diciplined with `hires_utc_clock`. 
 
-If `hires_utc_clock` jumps during a leap second then `hiperf_cutc_clock`  will filter out the leap second
+`hiperf_cutc_clock` is a std::chrono clock. This is a clock with 1ns resolution, but its actual precision
+is based on a CPU counter and disciplined with `hires_utc_clock`.
+
+If `hires_utc_clock` jumps during a leap second then `hiperf_cutc_clock` will filter out the leap second
 and keep counting as if there has not been a leap second. A `leapsecond_offset` attribute tracks the
 detected jumps.
 
 If `hires_utc_clock` slews during the leap second then `hiperf_cutc_clock` will slew with it.
-
-

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,17 +1,20 @@
-# TTauri time handling.
+TTauri time handling
+====================
 
-## High resolution UTC.
+High resolution UTC
+-------------------
 
 `hires_utc_clock` is a std::chrono clock. This is a clock with 1ns resolution, but its actual precision
 is based on the clock of the operating system:
 
-- POSIX `clock_gettime(CLOCK_REALTIME)`
-- Windows 10 `GetSystemTimeAsFileTime()`
-- macOS/iOS `gettimeofday()`
+ - POSIX `clock_gettime(CLOCK_REALTIME)`
+ - Windows 10 `GetSystemTimeAsFileTime()`
+ - macOS/iOS `gettimeofday()`
 
 During leap-seconds the UTC clock may slew or jump depending on how the operating system clock operates.
 
-## High performance Continues-UTC
+High performance Continues-UTC
+------------------------------
 
 `hiperf_cutc_clock` is a std::chrono clock. This is a clock with 1ns resolution, but its actual precision
 is based on a CPU counter and disciplined with `hires_utc_clock`.


### PR DESCRIPTION
fixed markdown formatting (use # for headings consistently, indentations on lists, newlines after headings)
fixed some spelling issues