### PR TITLE
small fixes

### DIFF
--- a/src/ttauri/bezier.hpp
+++ b/src/ttauri/bezier.hpp
@@ -248,7 +248,7 @@ inline float bezierFlatness(point2 P1, point2 C1, point2 C2, point2 P2) noexcept
     return P1P2 / (P1C1 + C1C2 + C2P2);
 }
 
-inline std::pair<point2, point2> parrallelLine(point2 P1, point2 P2, float distance) noexcept
+inline std::pair<point2, point2> parallelLine(point2 P1, point2 P2, float distance) noexcept
 {
     ttlet v = P2 - P1;
     ttlet n = normal(v);

--- a/src/ttauri/bezier_curve.cpp
+++ b/src/ttauri/bezier_curve.cpp
@@ -95,12 +95,12 @@ std::vector<bezier_curve> makeInverseContour(std::vector<bezier_curve> const &co
 }
 
 
-std::vector<bezier_curve> makeParrallelContour(std::vector<bezier_curve> const &contour, float offset, LineJoinStyle lineJoinStyle, float tolerance) noexcept
+std::vector<bezier_curve> makeParallelContour(std::vector<bezier_curve> const &contour, float offset, LineJoinStyle lineJoinStyle, float tolerance) noexcept
 {
     auto contourAtOffset = std::vector<bezier_curve>{};
     for (ttlet &curve: contour) {
         for (ttlet &flatCurve: curve.subdivideUntilFlat(tolerance)) {
-            contourAtOffset.push_back(flatCurve.toParrallelLine(offset));
+            contourAtOffset.push_back(flatCurve.toParallelLine(offset));
         }
     }
 
@@ -128,7 +128,7 @@ std::vector<bezier_curve> makeParrallelContour(std::vector<bezier_curve> const &
         } else {
             r.emplace_back(r.back().P2, curve.P1);
             r.push_back(curve);
-        } 
+        }
     }
 
     // Repair the endpoints of the contour as well.
@@ -425,7 +425,7 @@ void fill(pixel_map<sdf_r8> &image, std::vector<bezier_curve> const &curves) noe
         if (std::ssize(bad_pixel_list) == 0) {
             break;
         }
-    
+
         for (ttlet &[x, y]: bad_pixel_list) {
             image[y][x].repair();
         }

--- a/src/ttauri/bezier_curve.hpp
+++ b/src/ttauri/bezier_curve.hpp
@@ -281,9 +281,9 @@ struct bezier_curve {
      * \param offset positive means the parallel line will be on the starboard of the curve.
      * \return line segment offset from the curve.
      */
-    [[nodiscard]] bezier_curve toParrallelLine(float const offset) const noexcept
+    [[nodiscard]] bezier_curve toParallelLine(float const offset) const noexcept
     {
-        auto [newP1, newP2] = parrallelLine(P1, P2, offset);
+        auto [newP1, newP2] = parallelLine(P1, P2, offset);
         return {newP1, newP2};
     }
 
@@ -341,7 +341,7 @@ makeContourFromPoints(std::vector<bezier_point>::const_iterator first, std::vect
  * \param lineJoinStyle how the gaps between line segments are joined together.
  * \param tolerance to how curved the new contour should look.
  */
-[[nodiscard]] std::vector<bezier_curve> makeParrallelContour(
+[[nodiscard]] std::vector<bezier_curve> makeParallelContour(
     std::vector<bezier_curve> const &contour,
     float offset,
     LineJoinStyle lineJoinStyle,

--- a/src/ttauri/codec/base_n.hpp
+++ b/src/ttauri/codec/base_n.hpp
@@ -27,7 +27,7 @@ struct base_n_alphabet {
 
     /** Construct an alphabet.
      * @param str A null terminated string as a char array.
-     * @param case_insensitive The alphabet is case incensitive for decoding.
+     * @param case_insensitive The alphabet is case insensitive for decoding.
      * @param padding_char The character used to complete the last block during encoding.
      */
     template<size_t StringLength>
@@ -72,7 +72,7 @@ struct base_n_alphabet {
     }
 
     /** Get a character from an integer.
-     * The integer must be in range of 0 to modula (exlusive).
+     * The integer must be in range of 0 to modula (exclusive).
      */
     constexpr char char_from_int(int8_t x) const noexcept
     {

--- a/src/ttauri/graphic_path.cpp
+++ b/src/ttauri/graphic_path.cpp
@@ -123,7 +123,7 @@ void graphic_path::optimizeLayers() noexcept
     decltype(layerEndContours) tmp;
     tmp.reserve(std::ssize(layerEndContours));
 
-    auto prev_i = layerEndContours.begin(); 
+    auto prev_i = layerEndContours.begin();
     for (auto i = prev_i + 1; i != layerEndContours.end(); ++i) {
         // Add the last layer of a contiguous color.
         if (prev_i->second != i->second) {
@@ -444,10 +444,10 @@ graphic_path graphic_path::toStroke(float strokeWidth, LineJoinStyle lineJoinSty
     for (int i = 0; i < numberOfContours(); i++) {
         ttlet baseContour = getBeziersOfContour(i);
 
-        ttlet starboardContour = makeParrallelContour(baseContour, starboardOffset, lineJoinStyle, tolerance);
+        ttlet starboardContour = makeParallelContour(baseContour, starboardOffset, lineJoinStyle, tolerance);
         r.addContour(starboardContour);
 
-        ttlet portContour = makeInverseContour(makeParrallelContour(baseContour, portOffset, lineJoinStyle, tolerance));
+        ttlet portContour = makeInverseContour(makeParallelContour(baseContour, portOffset, lineJoinStyle, tolerance));
         r.addContour(portContour);
     }
 
@@ -496,7 +496,7 @@ graphic_path graphic_path::centerScale(extent2 extent, float padding) const noex
         max_size.height() / bbox.height()
     );
     bbox = scale2(scale) * bbox;
-    
+
     ttlet offset = (point2{} - get<0>(bbox)) + (extent - bbox.extent()) * 0.5;
 
     return (translate2(offset) * scale2(scale, scale)) * *this;

--- a/src/ttauri/version.hpp
+++ b/src/ttauri/version.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace tt {
 

--- a/src/ttauri/widgets/toolbar_tab_button_widget.hpp
+++ b/src/ttauri/widgets/toolbar_tab_button_widget.hpp
@@ -20,7 +20,7 @@ template<typename T>
 class toolbar_tab_button_widget final : public abstract_radio_button_widget<T> {
 public:
     using super = abstract_radio_button_widget<T>;
-    using value_type = super::value_type;
+    using value_type = typename super::value_type;
 
     observable<label> label;
 
@@ -155,7 +155,7 @@ private:
             };
 
             context.set_clipping_rectangle(line_rectangle);
-            
+
             if (overlaps(context, line_rectangle)) {
                 // Draw the line above every other direct child of the toolbar, and between
                 // the selected-tab (0.6) and unselected-tabs (0.8).


### PR DESCRIPTION
- fixed some spellings, including method rename `parrallelLine` to `parallelLine` on bezier*
- fixed some spellings
- added missing header
- added missing typename