### PR TITLE
Some fixes

### DIFF
--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -18,18 +18,19 @@ jobs:
 
 # ---------------------------------------------------------------------------------------
 
-    name: ${{ matrix.config.VCPKG_TARGET_TRIPLET }} PCH:${{ matrix.config.TT_BUILD_PCH }}
+    name: ${{ matrix.config.COMPILER}} | ${{ matrix.config.VCPKG_TARGET_TRIPLET }} | PCH:${{ matrix.config.TT_BUILD_PCH }}
     needs: install-vulkan-sdk-and-runtime
     # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
-    runs-on: windows-latest
+    # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
+    runs-on: ${{ matrix.config.OS }}
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - { VCPKG_TARGET_TRIPLET: x64-windows-static, TT_BUILD_PCH: OFF}
-          - { VCPKG_TARGET_TRIPLET: x64-windows-static, TT_BUILD_PCH: ON}
-          #- { VCPKG_TARGET_TRIPLET: x64-windows,       TT_BUILD_PCH: ON}
+          - { OS: windows-2019, VCPKG_TARGET_TRIPLET: x64-windows-static, TT_BUILD_PCH: OFF, COMPILER: "VC16"}
+          - { OS: windows-2019, VCPKG_TARGET_TRIPLET: x64-windows-static, TT_BUILD_PCH: ON,  COMPILER: "VC16"}
+          - { OS: windows-2022, VCPKG_TARGET_TRIPLET: x64-windows-static, TT_BUILD_PCH: ON,  COMPILER: "VC17"}
 
     env:
       BUILD_TYPE: RelWithDebInfo
@@ -62,7 +63,7 @@ jobs:
           $NAME=$(jq -r .name vcpkg.json)
           $VERSION=$(jq -r .version vcpkg.json)
           $SHORT_HASH=$($env:GITHUB_SHA.substring(0,7))
-          $COMPILER="MSVC19"
+          $COMPILER="${{ matrix.config.COMPILER }}"
           $TRIPLET="${{ matrix.config.VCPKG_TARGET_TRIPLET }}"
           $BUILD_TYPE="$env:BUILD_TYPE"
           $ARTIFACT_NAME="$NAME-$VERSION-$SHORT_HASH-$COMPILER-$TRIPLET-$BUILD_TYPE"
@@ -78,7 +79,8 @@ jobs:
           key: use-wrong-cache-key-to-trigger-partial-matching-of-restore-keys
           restore-keys: cache-windows-vulkan
 
-      - name: 🔽 Install Visual Studio Components for C++, CMake, Win10SDK
+      - name: 🔽 Install Visual Studio 16 2019 - Components for C++, CMake, Win10SDK
+        if: matrix.config.COMPILER == 'VC16'
         shell: pwsh
         run: |
           $VSConfig = Resolve-Path ".\.github\.vsconfig" | select -ExpandProperty Path
@@ -88,8 +90,14 @@ jobs:
           $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
           $process.ExitCode
 
-      - name: 📥 Setup VC Environment (➔ vcvarsall)
+      - name: 📥 Setup VC16 Environment (➔ vcvarsall)
+        if: matrix.config.COMPILER == 'VC16'
         run: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
+
+      # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022
+      - name: 📥 Setup VC17 Environment (→ vcvarsall)
+        if: matrix.config.COMPILER == 'VC17'
+        run: call "C:/Program Files/Microsoft Visual Studio/2022/Preview/VC/Auxiliary/Build/vcvars64.bat"
 
       - name: 🔽 Update VCPKG
         run: |
@@ -117,8 +125,11 @@ jobs:
 
       - name: ✏ CMake ➔ Configure (including VCPKG ➔ Install Dependencies)
         run: |
+          if "${{ matrix.config.COMPILER }}" == "VC16"; set "GENERATOR=Visual Studio 16 2019"
+          if "${{ matrix.config.COMPILER }}" == "VC17"; set "GENERATOR=Visual Studio 17 2022"
+          echo %GENERATOR%
           mkdir build && cd build
-          cmake -G "Visual Studio 16 2019" -A ${{ env.PLATFORM }} ..                        ^
+          cmake -G "%GENERATOR%" -A ${{ env.PLATFORM }} ..                                    ^
                 -DCMAKE_BUILD_TYPE=%BUILD_TYPE%                                             ^
                 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake            ^
                 -DVCPKG_TARGET_TRIPLET=${{ matrix.config.VCPKG_TARGET_TRIPLET }}            ^
@@ -157,7 +168,7 @@ jobs:
           $xsl.Load("${{ github.workspace }}\.github\gtest_to_junit.xsl")
           $xsl.Transform((Resolve-Path .\test_results_gtest.xml), "${{ github.workspace }}\test_results.xml")
           cd ${{ github.workspace }}
-          ren test_results.xml test_results_${{ matrix.config.VCPKG_TARGET_TRIPLET }}_PCH_${{ matrix.config.TT_BUILD_PCH }}.xml
+          ren test_results.xml test_results_${{ matrix.config.COMPILER }}_${{ matrix.config.VCPKG_TARGET_TRIPLET }}_PCH_${{ matrix.config.TT_BUILD_PCH }}.xml
 
       # We upload multiple files into the same artifact file (zip).
       # Each file is differently named by adding the job name of the matrix as a suffix.
@@ -196,7 +207,7 @@ jobs:
 
 # ---------------------------------------------------------------------------------------
 
-    name: "Install Vulkan SDK & Runtime [x64]"
+    name: "Install Vulkan SDK"
     runs-on: windows-latest
     if: success() || failure() # don't run job, if skipped
     defaults:
@@ -234,7 +245,7 @@ jobs:
         if: steps.cache-vulkan.outputs.cache-hit != 'true'
         run: |
           curl -L --silent --show-error --output VulkanSDK.exe %VULKAN_SDK_URL%
-          VulkanSDK.exe /S
+          VulkanSDK.exe in com.lunarg.vulkan.core --accept-licenses --default-answer --confirm-command --root %VULKAN_SDK%
 
       - name: 🔽 Install VULKAN Runtime (➔ vulkan-1.dll)
         if: steps.cache-vulkan.outputs.cache-hit != 'true'
@@ -253,13 +264,14 @@ jobs:
         run: |
           cd ${{ env.VULKAN_SDK }}
           "Folder size before: {0:N2} MB" -f ((ls . -r | Measure-Object -Property Length -Sum).Sum / 1MB)
-          Remove-Item -Recurse -Force "Bin32"
           Remove-Item -Recurse -Force "Demos"
-          Remove-Item -Recurse -Force "Lib32"
+          Remove-Item -Recurse -Force "Helpers"
+          Remove-Item -Recurse -Force "installerResources"
+          Remove-Item -Recurse -Force "Licenses"
           Remove-Item -Recurse -Force "Templates"
-          Remove-Item -Recurse -Force "Third-Party"
           Remove-Item -Recurse -Force "Tools"
-          Remove-Item -Recurse -Force "Tools32"
+          Remove-Item -Recurse -Force "Source"
+          Remove-Item .\maintenancetool.*, .\components.xml, .\network.xml, .\installer.dat, .\InstallationLog.txt
           "Folder size after: {0:N2} MB" -f ((ls . -r | Measure-Object -Property Length -Sum).Sum / 1MB)
 
       - name: 📤 Set outputs

--- a/.github/workflows/cleanup-workflows.yml
+++ b/.github/workflows/cleanup-workflows.yml
@@ -1,0 +1,151 @@
+#
+# .github/workflows/cleanup-workflows.yml
+#
+# Copyright 2021 Ching Chow, Jens A. Koch.
+#
+# Taken from: https://github.community/t/delete-old-workflow-results/
+# This file is part of https://github.com/ttauri-project/ttauri
+
+name: Clean Workflow Runs
+
+on:
+  # This workflow runs at 00:00 daily.
+  schedule:
+  - cron: '0 0 * * *'  # GMT
+  # You can manually run this workflow.
+  workflow_dispatch:
+
+jobs:
+
+# ---------------------------------------------------------------------------------------
+
+  cleanup-workflows:
+
+# ---------------------------------------------------------------------------------------
+
+    name: "Clean Workflows"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: ✂ Remove cancelled or skipped workflow runs
+        uses: actions/github-script@v4 # https://github.com/actions/github-script
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const cancelled = await github.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              per_page: 100,
+              repo: context.repo.repo,
+              status: 'cancelled',
+            });
+
+            const skipped = await github.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              per_page: 100,
+              repo: context.repo.repo,
+              status: 'skipped',
+            });
+
+            for (const response of [cancelled, skipped]) {
+              for (const run of response.data.workflow_runs) {
+                console.log(`[Deleting] Run id ${run.id} of '${run.name}' is a cancelled or skipped run.`);
+                await github.actions.deleteWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id
+                });
+              }
+            }
+
+      - name: ✂ Remove 30 days old workflows runs
+        uses: actions/github-script@v4 # https://github.com/actions/github-script
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const days_to_expiration = 30;
+            const ms_in_day = 86400000;
+            const now = Date.now();
+            const pages = 5;
+
+            // list the workflows runs to remove here
+
+            const workflows = [
+              'build-docs.yml',
+              'build-on-windows.yml',
+              'codeql-analysis.yml',
+              'publish-PR-test-results.yml'
+            ]
+
+            let runs_to_delete = [];
+
+            for (const workflow of workflows) {
+              for (let page = 0; page < pages; page += 1) {
+                let response = await github.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  page: page,
+                  per_page: 100,
+                  repo: context.repo.repo,
+                  workflow_id: workflow
+                });
+
+                if (response.data.workflow_runs.length > 0) {
+                  for (const run of response.data.workflow_runs) {
+                    if (now - Date.parse(run.created_at) > ms_in_day * days_to_expiration) {
+                      runs_to_delete.push([run.id, run.name]);
+                    }
+                  }
+                }
+              }
+            }
+
+            for (const run of runs_to_delete) {
+              console.log(`[Deleting] Run id ${run[0]} of '${run[1]}' is older than ${days_to_expiration} days.`);
+              try {
+                await github.actions.deleteWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run[0]
+                });
+              } catch (error) {
+                // ignore errors
+              }
+            }
+
+      - name: ✂ Remove runs of the cleanup workflow itself
+        uses: actions/github-script@v4 # https://github.com/actions/github-script
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pages = 5;
+
+            let runs_to_delete = [];
+
+            for (let page = 0; page < pages; page += 1) {
+              let response = await github.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                page: page,
+                per_page: 100,
+                repo: context.repo.repo,
+                workflow_id: 'cleanup-workflows.yml'
+              });
+
+              if (response.data.workflow_runs.length > 0) {
+                for (const run of response.data.workflow_runs) {
+                    runs_to_delete.push([run.id, run.name]);
+                }
+              }
+            }
+
+            for (const run of runs_to_delete) {
+              console.log(`[Deleting] Run id ${run[0]} of '${run[1]}'.`);
+              try {
+                await github.actions.deleteWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run[0]
+                });
+              } catch (error) {
+                // ignore errors
+              }
+            }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,13 +177,6 @@ target_include_directories(ttauri PUBLIC
 target_include_directories(ttauri PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(ttauri PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
 
-if(${CMAKE_VERSION} VERSION_LESS "3.21.0")
-    target_compile_features(ttauri PUBLIC cxx_std_20)
-else()
-    # CMake uses the incorrect /std:c++20 on MSVC when cxx_std_20 is used.
-    target_compile_features(ttauri PUBLIC cxx_std_23)
-endif()
-
 #
 # We will support the following CPUs:
 #   * Intel Ivy Bridge from 2012, still used by Mac Pro sold in 2019.
@@ -219,6 +212,14 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
     endif()
 
 elseif (MSVC)
+
+    if(${CMAKE_VERSION} VERSION_LESS "3.21.0")
+        target_compile_features(ttauri PUBLIC cxx_std_20)
+    else()
+        # CMake uses the incorrect /std:c++20 on MSVC when cxx_std_20 is used.
+        target_compile_features(ttauri PUBLIC cxx_std_23)
+    endif()
+
     # Turn on a lot of warnings by default.
     target_compile_options(ttauri PUBLIC -W4)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,14 +7,15 @@ project(ttauri_utilities C)
 
 add_executable(embed_static_resource embed_static_resource.cpp)
 
-if(${CMAKE_VERSION} VERSION_LESS "3.21.0")
-    target_compile_features(embed_static_resource PUBLIC cxx_std_20)
-else()
-    # CMake uses the incorrect /std:c++20 on MSVC when cxx_std_20 is used.
-    target_compile_features(embed_static_resource PUBLIC cxx_std_23)
-endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
-if (MSVC)
+    if(${CMAKE_VERSION} VERSION_LESS "3.21.0")
+        target_compile_features(embed_static_resource PUBLIC cxx_std_20)
+    else()
+        # CMake uses the incorrect /std:c++20 on MSVC when cxx_std_20 is used.
+        target_compile_features(embed_static_resource PUBLIC cxx_std_23)
+    endif()
+
     target_compile_options(embed_static_resource PRIVATE -wd4068)
 
     # Set defines to compile a win32 application.


### PR DESCRIPTION
Hey T!

Here are some notes on the PR and it's changes:
- the "cxx_std_20/cxx_std_23 bugfix section" was moved into the MSVC section, because clang-cl doesn't know these compiler flags and stopped configuring
- added a `cleanup-workflows.yml`, which runs scheduled and removes all skip/cancelled/old jobs (there are over 1,3k total jobs now^^ oof, that escalated quickly)
   - especially the annoying skipped "Publish PR Test Result" jobs should disapear after merging
- added "Visual Studio 17 2022" (windows-2022 image) to the build matrix, but only for PCH:ON
   - i've decided to use `VC16` and `VC17` for a `COMPILER` variable, which replaces the `MSVC19` on artifact filenames and is now also part of the workflow job name
- fixed the Vulkan SDK installation
  - they switched their installer type to "Qt Installer Framework" from formerly NSIS(?)
    and use a component based install/maintenance system now. new silent install switch
   - sdk has a new folder layout, adjusted the reduce step accordingly 
   - shortened workflow job name

Ref. https://github.com/jakoch/ttauri/actions/runs/1247784359

Please review and comment on the code, so that we can get it into a state, where it is ready to be merged.
Regards, Jens