### PR TITLE
some_fixes_1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ endif()
 
 include(AddStaticResource)
 include(AddShader)
-include(AddStaticResource)
 include(ShowBuildTargetProperties)
 include(FetchContent)
 if(WIN32)
@@ -101,7 +100,7 @@ endif()
 #
 if(TT_BUILD_TESTS)
     set(INSTALL_GTEST OFF CACHE INTERNAL "Don't install gtest")
-    set(INSTALL_GMOCK OFF CACHE INTERNAL "Don't install gmock")
+    set(BUILD_GMOCK OFF CACHE INTERNAL "Don't build gmock")
     FetchContent_Declare(googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG release-1.11.0)
     FetchContent_MakeAvailable(googletest)
 endif()
@@ -312,7 +311,7 @@ elseif (MSVC)
         target_compile_options(ttauri PUBLIC -analyze)
 
         #target_compile_options(ttauri PUBLIC -analyze:ruleset ${CMAKE_CURRENT_SOURCE_DIR}/AllRules.ruleset)
-        
+
         # The Core Guidelines checker, not so useful for real programs.
         #target_compile_options(ttauri PUBLIC -analyze:plugin EspXEngine.dll)
     endif()

--- a/examples/custom_widgets/CMakeLists.txt
+++ b/examples/custom_widgets/CMakeLists.txt
@@ -8,6 +8,8 @@ add_custom_target(custom_widget_example_resources
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/resources ${CMAKE_CURRENT_BINARY_DIR}/resources
     DEPENDS
     ttauri
+    resources/copyright.md
+    resources/mars3.png
 )
 
 add_executable(minimum_custom_widget_example WIN32 MACOSX_BUNDLE)
@@ -42,6 +44,8 @@ install(TARGETS minimum_custom_widget_example DESTINATION examples/custom_widget
 install(TARGETS custom_widget_with_child_example DESTINATION examples/custom_widgets)
 install(TARGETS custom_widget_command_example DESTINATION examples/custom_widgets)
 install(TARGETS custom_widget_drawing_example DESTINATION examples/custom_widgets)
+
+install(DIRECTORY resources/ DESTINATION examples/custom_widgets/resources)
 
 # copy additional "ttauri library" resources from top-level
 install(DIRECTORY ../../resources/  DESTINATION examples/custom_widgets/resources)


### PR DESCRIPTION
- remove duplicate `include(AddStaticResource)`
- `INSTALL_GMOCK` build option was removed in googletest upstream, it's now `BUILD_GMOCK`
- install `custom_widgets/resources` (mars image was missing after install)